### PR TITLE
Update season year from 2025 to 2026 and implement historical stats

### DIFF
--- a/client/src/components/AppFooter.tsx
+++ b/client/src/components/AppFooter.tsx
@@ -11,7 +11,7 @@ const AppFooter = () => {
             {mode === 'edit' && <ShareRanking />}
             
             <div className="footer-info">
-                <p>Player data sourced from ESPN | 2025 Projections sourced from Fangraphs</p>
+                <p>Player data sourced from ESPN | 2026 Projections sourced from Fangraphs</p>
             </div>
         </footer>
     )

--- a/client/src/components/PlayerList/PlayerCard.tsx
+++ b/client/src/components/PlayerList/PlayerCard.tsx
@@ -78,24 +78,6 @@ const PlayerCard = ({ playerId, onClose }) => {
                             </tr>
                         </thead>
                         <tbody>
-                            {/* 2023 Stats Row */}
-                            <tr>
-                                <td className="year">2023</td>
-                                {columns.map(column => {
-                                    if (stats && stats['2023'] && stats['2023'][column.id]) {
-                                        const value = stats['2023'][column.id];
-                                        const formattedValue = formatStatValue(column.id, value);
-                                        return (
-                                            <td key={column.id}>
-                                                {formattedValue}
-                                            </td>
-                                        );
-                                    } else {
-                                        return <td key={column.id}>-</td>;
-                                    }
-                                })}
-                            </tr>
-                            
                             {/* 2024 Stats Row */}
                             <tr>
                                 <td className="year">2024</td>
@@ -113,10 +95,28 @@ const PlayerCard = ({ playerId, onClose }) => {
                                     }
                                 })}
                             </tr>
-                            
-                            {/* 2025 Projections Row */}
+
+                            {/* 2025 Stats Row */}
+                            <tr>
+                                <td className="year">2025</td>
+                                {columns.map(column => {
+                                    if (stats && stats['2025'] && stats['2025'][column.id]) {
+                                        const value = stats['2025'][column.id];
+                                        const formattedValue = formatStatValue(column.id, value);
+                                        return (
+                                            <td key={column.id}>
+                                                {formattedValue}
+                                            </td>
+                                        );
+                                    } else {
+                                        return <td key={column.id}>-</td>;
+                                    }
+                                })}
+                            </tr>
+
+                            {/* 2026 Projections Row */}
                             <tr className="projections">
-                                <td className="year">2025 (Proj)</td>
+                                <td className="year">2026 (Proj)</td>
                                 {columns.map(column => {
                                     if (projections && projections[column.id]) {
                                         const value = projections[column.id];


### PR DESCRIPTION
## Summary
This PR updates the application to support the 2026 MLB season and implements historical stats fetching from the ESPN Fantasy API. The changes ensure the app displays current season data (2026) alongside prior year stats (2024-2025) and projections.

## Key Changes

- **Season Updates**: Updated all ESPN API endpoints and UI references from 2025 to 2026 season
  - Updated player list and stats API calls to use 2026 season
  - Updated footer and player card displays to show 2026 projections
  - Updated FanGraphs projection URLs to request 2026 season data

- **Historical Stats Implementation**: Replaced placeholder TODO with functional implementation
  - Implemented `fetchHistoricalStats()` to fetch 2025 season data from ESPN Fantasy API
  - Fetches both batter and pitcher historical stats using appropriate filter slots
  - Processes and formats historical stats for storage

- **Data Merging**: Updated player store building to merge historical and current season stats
  - Historical stats are fetched for prior years (2024-2025)
  - Current season stats (2026) are merged with historical data
  - Current season stats take precedence in case of conflicts

- **Admin Refresh**: Added 'historical' to the sources updated during admin refresh operations
  - Ensures historical stats are refreshed alongside current season data

- **Minor Cleanup**: Fixed whitespace inconsistencies in PlayerCard component

## Implementation Details

The historical stats are now fetched from the ESPN Fantasy API's 2025 season endpoint, providing a complete picture of player performance across multiple years. The stats are properly merged so that the player store contains both historical context and current season projections.

https://claude.ai/code/session_01S9tD1ZgJ3rhUpX1vDbkqRx