### PR TITLE
 paginate FanGraphs API and wire up player list fetch

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -328,8 +328,8 @@ app.get('/admin', (c) => c.html())
  * TODO: Setup criteria
  */
 app.get('/admin/refresh', async (c) => {
-    const VALID_SOURCES = ['teams', 'stats', 'projections', 'historical'];
-    const sources_to_update = ['teams', 'stats', 'projections', 'historical'];
+    const VALID_SOURCES = ['teams', 'players', 'stats', 'projections', 'historical'];
+    const sources_to_update = ['teams', 'players', 'stats', 'projections', 'historical'];
 
     // Validate sources_to_update
     if (sources_to_update.length < 1) {
@@ -361,6 +361,19 @@ app.get('/admin/refresh', async (c) => {
     console.log(`Teams found: ${teams.length}`);
     console.log(`Divisions found: ${divisions.length}`);
 
+    // Fetch the broad player list from ESPN
+    let playerList = [];
+    if (sources_to_update.includes('players')) {
+        playerList = await fetchMLBPlayerList();
+        storePlayerList(playerList);
+        console.log(`Player list refreshed: ${playerList.length} players`);
+    } else {
+        let entries = kv.list({ prefix: ['playerlist'] });
+        for await (let entry of entries) {
+            playerList.push(entry.value);
+        }
+    }
+
     // Fetch player stats and details - this now includes both stats and player data
     let playerStats = {};
     let playerDetails = {};
@@ -376,13 +389,36 @@ app.get('/admin/refresh', async (c) => {
         for await (let entry of entries) {
             playerStats[entry.key[1]] = entry.value;
         }
-        
+
         // Load player details
         entries = kv.list({ prefix: ['players']});
         for await (let entry of entries) {
             playerDetails[entry.key[1]] = entry.value;
         }
     }
+
+    // Supplement playerDetails with any players from the broad player list
+    // that weren't captured by fetchPlayerStats (which has limited results)
+    for (const player of playerList) {
+        if (!playerDetails[player.id]) {
+            playerDetails[player.id] = {
+                id: player.id,
+                fullName: player.fullName,
+                firstName: player.firstName,
+                lastName: player.lastName,
+                injuryStatus: player.injuryStatus || null,
+                defaultPositionId: player.defaultPositionId,
+                eligibleSlots: player.eligibleSlots || [],
+                proTeamId: player.proTeamId,
+                ownership: player.ownership?.percentOwned || 0,
+                averageDraftPosition: player.ownership?.averageDraftPosition || null,
+                percentChange: player.ownership?.percentChange || null,
+                birthDate: player.dateOfBirth || null,
+                age: calculateAge(player.dateOfBirth)
+            };
+        }
+    }
+
     console.log(`Stats found for players: ${Object.keys(playerStats).length}`);
     console.log(`Player details found: ${Object.keys(playerDetails).length}`);
 


### PR DESCRIPTION
## Summary
- Paginate FanGraphs leaders API to fetch all player stats (the API caps
  results per page, so the previous single request missed players)
- Wire up `fetchMLBPlayerList` in the refresh endpoint — it was defined but
  never called. `fetchPlayerStats` is capped at 500 batters + 400 pitchers,
  so new or low-ownership players were missed. The broad player list now
  supplements `playerDetails` with anyone not already captured.

## Test plan
- [ ] Run `/admin/refresh` and check log output for player counts
- [ ] Verify new/low-ownership players now appear in the response
- [ ] Confirm FanGraphs log lines show higher batter/pitcher counts than before

https://claude.ai/code/session_01S9tD1ZgJ3rhUpX1vDbkqRx
