### PR TITLE
Fix local ranking ID display format

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -232,8 +232,8 @@ const AppHeader = () => {
                             <div className="ranking-header">
                                 <span className="id-label">Ranking:</span>
                                 <span className="id-value">
-                                    {ranking.id && ranking.id.startsWith('local') 
-                                        ? '#0000' 
+                                    {ranking.id && ranking.id.startsWith('local')
+                                        ? `#${ranking.id.substr(-4)}`
                                         : `#${ranking.id}`}
                                 </span>
                             </div>
@@ -393,9 +393,9 @@ const AppHeader = () => {
                             <div className="current-ranking-details">
                                 <h4>Current Ranking</h4>
                                 <div className="ranking-name">
-                                    {ranking.id && ranking.id.startsWith('local') 
-                                        ? `#${ranking.id.substr(6, 4)}`
-                                        : (ranking.name || (ranking.author 
+                                    {ranking.id && ranking.id.startsWith('local')
+                                        ? `#${ranking.id.substr(-4)}`
+                                        : (ranking.name || (ranking.author
                                             ? `${ranking.author}'s Ranking` 
                                             : `Ranking #${ranking.id}`))}
                                 </div>


### PR DESCRIPTION
## Summary
Fixed the display format for local ranking IDs to correctly extract and show the last 4 characters of the ID string.

## Key Changes
- Updated ranking ID display logic in two locations (AppHeader component) to use `substr(-4)` instead of hardcoded `#0000` or incorrect `substr(6, 4)` offset
- This ensures local ranking IDs (which start with 'local') properly display their unique identifier suffix
- Cleaned up whitespace formatting for consistency

## Implementation Details
- Changed line 235: `#0000` → `` `#${ranking.id.substr(-4)}` `` to dynamically extract the last 4 characters
- Changed line 396: `substr(6, 4)` → `substr(-4)` to use negative indexing, which is more reliable for extracting the suffix regardless of the full ID length
- Both changes ensure consistent behavior across the component when displaying local ranking identifiers

https://claude.ai/code/session_01DLWofT9sieRiQc8ixdvpew