### PR TITLE
Add player notes feature to rankings

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -833,8 +833,60 @@ button[data-disabled] {
 }
 
 /**
- * PlayerItem 
+ * PlayerItem
  */
+
+.player-item-row {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 100%;
+}
+
+.player-note {
+  padding: 0.25rem 0.5rem 0.25rem calc(0.5rem + 64px + 0.5rem + 0.5rem);
+}
+
+.player-note-input {
+  width: 100%;
+  resize: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  background: transparent;
+  font-family: inherit;
+  font-size: 0.75rem;
+  color: var(--greybrown);
+  padding: 0.2rem 0.4rem;
+  line-height: 1.4;
+  transition: border-color 0.15s ease, background 0.15s ease;
+  overflow: hidden;
+
+  &::placeholder {
+    color: var(--faded);
+    font-style: italic;
+  }
+
+  &:hover {
+    border-color: var(--tan-dark);
+    background: rgba(255, 255, 255, 0.5);
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--greybrown);
+    background: white;
+    color: var(--brown);
+    resize: vertical;
+  }
+}
+
+.player-note--readonly .player-note-text {
+  font-size: 0.75rem;
+  color: var(--greybrown);
+  font-style: italic;
+  padding: 0.2rem 0.4rem;
+  margin: 0;
+}
 
 ol {
   padding-left: 0;
@@ -879,8 +931,8 @@ ol li::before {
   border-radius: 8px;
 
   display: flex;
-  justify-content: flex-start;
-  align-items: center;
+  flex-direction: column;
+  align-items: stretch;
 
   &.highlighted {
     border-color: var(--gold);

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react'
+import {useContext, useState} from 'react'
 import {StoreContext} from '~/data/store'
 import {DraftContext} from '~/data/draftContext'
 import {StatsPrefsContext} from '~/data/statsPrefsContext'
@@ -9,12 +9,16 @@ const EXLUDED_POSITIONS = ['1B/3B', '2B/SS', 'P', 'UTIL']
 
 const PlayerItem = (props) => {
     const {playerId, playerRanking, editable, onNameClick} = props
-    const {players, teams, mode, ignorePlayer, highlightPlayer} = useContext(StoreContext);
+    const {players, teams, mode, ignorePlayer, highlightPlayer, updatePlayerNote, userRanking} = useContext(StoreContext);
     const {isMyTurn, draftPlayer} = useContext(DraftContext);
     const {selectedBattingStats, selectedPitchingStats} = useContext(StatsPrefsContext);
     
     const isDraftMode = mode === 'draft';
-    
+
+    // Notes are editable when the ranking is yours (local, or shared with PIN)
+    const notesEditable = !userRanking?.isShared || !!userRanking?.pin;
+    const [noteText, setNoteText] = useState(playerRanking?.note || '');
+
     const player = players[playerId]
     const projections = player.projections
 
@@ -78,93 +82,113 @@ const PlayerItem = (props) => {
 
     const className = `player-item ${playerRanking?.highlight ? 'highlighted' : playerRanking?.ignore ? 'ignored' : ''}`
 
+    const hasNote = !!playerRanking?.note;
+
     return (
         <div className={className}>
-            <div className="player-photos">
-                { teamLogo && (<img className="team-logo" src={teamLogo} width="32" />) }
-                <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="96" /> 
-            </div>
-            <div className="player-details">
-                <p className="player-name" onClick={onNameClick}>{player.name}</p>
-                <div className="player-positions small">
-                    {positions.map(position => (
-                        <span 
-                            key={position} 
-                            className="position-chip small"
-                            data-pos={position}
-                        >{position}</span>
-                    ))}
+            <div className="player-item-row">
+                <div className="player-photos">
+                    { teamLogo && (<img className="team-logo" src={teamLogo} width="32" />) }
+                    <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="96" />
                 </div>
-                <div className="player-status">
-                    {player.averageDraftPosition && (
-                        <div className="adp">
-                            <span className="adp-label">ADP</span> 
-                            <span className="adp-value">{Math.round(player.averageDraftPosition * 10) / 10}</span>
-                            {player.adpChange && (
-                                <span className={`adp-change ${player.adpChange > 0 ? 'positive' : 'negative'}`}>
-                                    ({player.adpChange > 0 ? '+' : ''}{player.adpChange}%)
-                                </span>
-                            )}
-                        </div>
-                    )}
-                    {player.injuryStatus && player.injuryStatus !== "ACTIVE" && (
-                        <div className="injury-status">
-                            {player.injuryStatus === "DAY_TO_DAY" ? "D2D" : player.injuryStatus}
-                        </div>
-                    )}
+                <div className="player-details">
+                    <p className="player-name" onClick={onNameClick}>{player.name}</p>
+                    <div className="player-positions small">
+                        {positions.map(position => (
+                            <span
+                                key={position}
+                                className="position-chip small"
+                                data-pos={position}
+                            >{position}</span>
+                        ))}
+                    </div>
+                    <div className="player-status">
+                        {player.averageDraftPosition && (
+                            <div className="adp">
+                                <span className="adp-label">ADP</span>
+                                <span className="adp-value">{Math.round(player.averageDraftPosition * 10) / 10}</span>
+                                {player.adpChange && (
+                                    <span className={`adp-change ${player.adpChange > 0 ? 'positive' : 'negative'}`}>
+                                        ({player.adpChange > 0 ? '+' : ''}{player.adpChange}%)
+                                    </span>
+                                )}
+                            </div>
+                        )}
+                        {player.injuryStatus && player.injuryStatus !== "ACTIVE" && (
+                            <div className="injury-status">
+                                {player.injuryStatus === "DAY_TO_DAY" ? "D2D" : player.injuryStatus}
+                            </div>
+                        )}
+                    </div>
                 </div>
-            </div>
-            <div className="player-stats">
-                <table>
-                    <thead>
-                        <tr>
-                            { columns.map(column => (<th key={column.id}>{column.name}</th>))}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>                            
-                            { columns.map(column => (<td key={column.id}>{renderCellValue(player, column.id)}</td>))}
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            {editable && !isDraftMode && (
-                <div className="player-actions">
-                    <button 
-                        onClick={onIgnore}
-                        className={playerRanking?.ignore ? 'ignored' : ''}
-                    >
-                        {playerRanking?.ignore ? 'unignore' : 'ignore'}
-                    </button>
-                    <button 
-                        onClick={onHighlight}
-                        className={playerRanking?.highlight ? 'highlighted' : ''}
-                    >
-                        {playerRanking?.highlight ? 'unhighlight' : 'highlight'}
-                    </button>
+                <div className="player-stats">
+                    <table>
+                        <thead>
+                            <tr>
+                                { columns.map(column => (<th key={column.id}>{column.name}</th>))}
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                { columns.map(column => (<td key={column.id}>{renderCellValue(player, column.id)}</td>))}
+                            </tr>
+                        </tbody>
+                    </table>
                 </div>
-            )}
-            
-            {isDraftMode && (
-                <div className="player-actions">
-                    {isMyTurn() ? (
-                        <button 
-                            onClick={onDraft}
-                            className="draft-button"
+                {editable && !isDraftMode && (
+                    <div className="player-actions">
+                        <button
+                            onClick={onIgnore}
+                            className={playerRanking?.ignore ? 'ignored' : ''}
                         >
-                            Draft
+                            {playerRanking?.ignore ? 'unignore' : 'ignore'}
                         </button>
-                    ) : (
-                        <button 
-                            onClick={onDraft}
-                            className="drafted-button"
+                        <button
+                            onClick={onHighlight}
+                            className={playerRanking?.highlight ? 'highlighted' : ''}
                         >
-                            Drafted
+                            {playerRanking?.highlight ? 'unhighlight' : 'highlight'}
                         </button>
-                    )}
+                    </div>
+                )}
+
+                {isDraftMode && (
+                    <div className="player-actions">
+                        {isMyTurn() ? (
+                            <button
+                                onClick={onDraft}
+                                className="draft-button"
+                            >
+                                Draft
+                            </button>
+                        ) : (
+                            <button
+                                onClick={onDraft}
+                                className="drafted-button"
+                            >
+                                Drafted
+                            </button>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {notesEditable ? (
+                <div className="player-note">
+                    <textarea
+                        className="player-note-input"
+                        placeholder="Add a note..."
+                        value={noteText}
+                        onChange={(e) => setNoteText(e.target.value)}
+                        onBlur={() => updatePlayerNote(playerId, noteText)}
+                        rows={1}
+                    />
                 </div>
-            )}
-           
+            ) : hasNote ? (
+                <div className="player-note player-note--readonly">
+                    <p className="player-note-text">{playerRanking.note}</p>
+                </div>
+            ) : null}
         </div>
     )
 }

--- a/client/src/data/store.tsx
+++ b/client/src/data/store.tsx
@@ -22,26 +22,28 @@ export const StoreProvider = ({ children }) => {
 
     // Use the enhanced user ranking hook that supports sharing
     const userRanking = useUserRanking(players)
-    const { 
-        ranking, 
-        isLoading: isLoadingRanking, 
-        updateRanking, 
-        ignorePlayer, 
-        highlightPlayer 
+    const {
+        ranking,
+        isLoading: isLoadingRanking,
+        updateRanking,
+        ignorePlayer,
+        highlightPlayer,
+        updatePlayerNote
     } = userRanking
 
     const error = errorFetchingMLBTeams || errorFetchingPlayers
     const isLoading = isLoadingMLBTeams || isLoadingPlayers || isLoadingRanking
 
-    const context = { 
+    const context = {
         teams,
         players,
         mode,
-        ranking, 
+        ranking,
         updateMode,
         updateRanking,
         ignorePlayer,
         highlightPlayer,
+        updatePlayerNote,
         userRanking // Expose the full userRanking object for sharing functionality
     }
 

--- a/client/src/data/useUserRanking.tsx
+++ b/client/src/data/useUserRanking.tsx
@@ -432,6 +432,45 @@ const useUserRanking = (players) => {
         }
     };
 
+    const updatePlayerNote = async (playerId, note) => {
+        const currentPlayerInfo = ranking.players[playerId] || { rank: 0, ignore: false, highlight: false };
+
+        const updatedPlayers = {
+            ...ranking.players,
+            [playerId]: {
+                ...currentPlayerInfo,
+                note: note || undefined
+            }
+        };
+
+        const now = Date.now();
+        const newRanking = {
+            ...ranking,
+            players: updatedPlayers,
+            updatedAt: now
+        };
+
+        setRanking(newRanking);
+        localStorage.setItem(`ranking_${newRanking.id}`, JSON.stringify(newRanking));
+        saveToRankingsList(newRanking);
+
+        if (isShared && !ranking.id.startsWith('local') && pin) {
+            try {
+                const updatedRemoteRanking = await updateRemoteRanking(
+                    ranking.id,
+                    { players: updatedPlayers },
+                    pin
+                );
+                updatedRemoteRanking.name = newRanking.name;
+                setRanking(updatedRemoteRanking);
+                localStorage.setItem(`ranking_${updatedRemoteRanking.id}`, JSON.stringify(updatedRemoteRanking));
+                saveToRankingsList(updatedRemoteRanking);
+            } catch (err) {
+                console.error('Failed to update remote ranking:', err);
+            }
+        }
+    };
+
     const ignorePlayer = async (playerId) => {
         const currentPlayerInfo = ranking.players[playerId] || { rank: 0, ignore: false, highlight: false };
         const isCurrentlyIgnored = currentPlayerInfo.ignore || false;
@@ -507,6 +546,7 @@ const useUserRanking = (players) => {
         updateRanking,
         highlightPlayer,
         ignorePlayer,
+        updatePlayerNote,
         shareRanking,
         loadRanking,
         createNewRanking,

--- a/server/types.ts
+++ b/server/types.ts
@@ -49,6 +49,7 @@ export interface Ranking {
         rank: number;
         ignore: boolean;
         highlight: boolean;
+        note?: string;
     }>;
 }
 


### PR DESCRIPTION
## Summary
This PR adds the ability to add and view notes for individual players in rankings. Notes are editable for local rankings and shared rankings with a PIN, but read-only for shared rankings without a PIN.

## Key Changes
- **PlayerItem Component**: 
  - Added `useState` hook to manage note text state
  - Implemented conditional note editing based on ranking sharing status (`notesEditable` logic)
  - Added textarea input for editable notes and read-only note display
  - Restructured JSX with new `player-item-row` wrapper for better layout organization

- **useUserRanking Hook**:
  - Added `updatePlayerNote` function to handle note persistence
  - Supports saving notes to localStorage for local rankings
  - Syncs notes to remote rankings when shared with PIN
  - Includes error handling for remote sync failures

- **Store Context**:
  - Exposed `updatePlayerNote` function through StoreContext
  - Exposed `userRanking` object to allow components to check sharing status

- **Type Definitions**:
  - Added optional `note?: string` field to player info in Ranking interface

- **Styling**:
  - Added `.player-item-row` flexbox container for horizontal layout
  - Added `.player-note` and `.player-note-input` styles with hover/focus states
  - Added `.player-note--readonly` variant for read-only notes
  - Updated `.player-item` to use `flex-direction: column` for vertical stacking

## Implementation Details
- Notes are stored in the player ranking data structure alongside rank, ignore, and highlight flags
- Empty notes are stored as `undefined` to keep data clean
- The textarea auto-saves on blur via `updatePlayerNote` callback
- Read-only notes display in italic styling to distinguish from editable state
- Note input is positioned to align with player photo using calculated padding

https://claude.ai/code/session_018FcCbB8LqwEsAqxKsiZU2W