### PR TITLE
Fix player list reordering to preserve drag-and-drop changes

### DIFF
--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -34,7 +34,10 @@ const PlayerList = ({ editable }: any) => {
     const isDraftMode = mode === 'draft';
     const draftedPlayerIds = isDraftMode ? Object.values(draftedPlayers) : [];
 
-    // Initialize and update the ordered player list based on rank
+    // Initialize and update the ordered player list based on rank.
+    // Only re-initialize when the ranking itself changes (different ranking loaded),
+    // not when player properties like ignore/highlight change within the same ranking —
+    // those updates must not overwrite unsaved drag-and-drop reordering.
     useEffect(() => {
         if (ranking.players && Object.keys(ranking.players).length > 0) {
             // Convert the players object to an ordered array
@@ -42,10 +45,10 @@ const PlayerList = ({ editable }: any) => {
             const orderedIds = [...playerIds].sort((a, b) => {
                 return ranking.players[a].rank - ranking.players[b].rank
             });
-            
+
             setRankedPlayerIds(orderedIds);
         }
-    }, [ranking.players]);
+    }, [ranking.id]);
 
     /* DND-KIT config */
     // Setup sensors, needed to support touch events on mobile.


### PR DESCRIPTION
## Summary
Fixed an issue where drag-and-drop reordering of players was being overwritten when player properties (like ignore/highlight status) changed within the same ranking.

## Key Changes
- Changed the `useEffect` dependency from `[ranking.players]` to `[ranking.id]` to prevent unnecessary re-initialization of the player list order
- Updated the effect to only re-initialize the ordered player list when a different ranking is loaded, not when individual player properties change
- Added clarifying comments explaining the rationale for this dependency change

## Implementation Details
The previous implementation would re-run the effect whenever any player property changed (since `ranking.players` is an object reference that changes on any mutation). This caused the ranked player list to be reset to the original ranking order, overwriting any unsaved drag-and-drop reordering the user had performed.

By changing the dependency to `ranking.id`, the effect now only re-initializes when the user loads a completely different ranking, while preserving manual reordering within the same ranking session.

https://claude.ai/code/session_016UjRtuVyjz78C9M9i8ioK4