### PR TITLE
Add fallback image handling and fix notes editability logic

### DIFF
--- a/client/src/components/PlayerList/PlayerCard.tsx
+++ b/client/src/components/PlayerList/PlayerCard.tsx
@@ -45,7 +45,7 @@ const PlayerCard = ({ playerId, onClose }) => {
                 <div className="player-card-header">
                     <div className="player-photos large">
                         { teamLogo && (<img className="team-logo" src={teamLogo} width="48" />) }
-                        <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="180" /> 
+                        <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="180" onError={(e) => { (e.target as HTMLImageElement).src = '/assets/images/player-fallback.png'; }} />
                     </div>
                     <div className="player-info">
                         <h2>{player.name}</h2>

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -15,8 +15,8 @@ const PlayerItem = (props) => {
     
     const isDraftMode = mode === 'draft';
 
-    // Notes are editable when the ranking is yours (local, or shared with PIN)
-    const notesEditable = !userRanking?.isShared || !!userRanking?.pin;
+    // Notes are editable when in edit mode and the ranking is yours (local, or shared with PIN)
+    const notesEditable = editable && (!userRanking?.isShared || !!userRanking?.pin);
     const [noteText, setNoteText] = useState(playerRanking?.note || '');
 
     const player = players[playerId]
@@ -89,7 +89,7 @@ const PlayerItem = (props) => {
             <div className="player-item-row">
                 <div className="player-photos">
                     { teamLogo && (<img className="team-logo" src={teamLogo} width="32" />) }
-                    <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="96" />
+                    <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="96" onError={(e) => { (e.target as HTMLImageElement).src = '/assets/images/player-fallback.png'; }} />
                 </div>
                 <div className="player-details">
                     <p className="player-name" onClick={onNameClick}>{player.name}</p>


### PR DESCRIPTION
## Summary
This PR improves the robustness of player image handling and fixes a bug in the notes editability logic.

## Key Changes
- **Image fallback handling**: Added `onError` handlers to player headshot images in both `PlayerItem` and `PlayerCard` components. When an image fails to load, it now falls back to a placeholder image (`/assets/images/player-fallback.png`) instead of displaying a broken image.
- **Notes editability fix**: Updated the `notesEditable` logic in `PlayerItem` to require both the `editable` prop AND ownership conditions (local or shared with PIN). Previously, notes could be marked as editable based only on ownership, regardless of the `editable` prop value.

## Implementation Details
- The image fallback uses a simple error handler that casts the event target to `HTMLImageElement` and updates the `src` attribute
- The notes editability now correctly gates editing behind both the edit mode state and ownership validation, preventing unintended note modifications

https://claude.ai/code/session_01VZXDvKpsF3vXxoUEgdi3Lm