### PR TITLE
Fix DH position filtering in PlayerList

### DIFF
--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -77,7 +77,11 @@ const PlayerList = ({ editable }: any) => {
         const player = players?.[playerId]
         if (!player) { return false }
         if (isDraftMode && draftedPlayerIds.includes(playerId)) { return false; }
-        return posFilter ? player.pos.includes(posFilter) : true
+        if (!posFilter) return true
+        if (posFilter === 'DH') {
+            return player.pos.every(p => p === 'DH' || p === 'UTIL')
+        }
+        return player.pos.includes(posFilter)
     }
 
     const columns = isDraftMode


### PR DESCRIPTION
## Summary
Updated the position filter logic in PlayerList to correctly handle DH (Designated Hitter) position filtering. Previously, the filter used a simple `includes()` check which didn't account for the special case where DH players can also have a UTIL (Utility) position designation.

## Changes
- Refactored the position filter condition to handle DH as a special case
- DH filter now uses `every()` to ensure players match DH or UTIL positions (both are valid for DH slots)
- Other position filters continue to use the standard `includes()` check
- Improved code readability by extracting the filter logic into separate conditional statements

## Implementation Details
The DH position has unique filtering requirements compared to other positions. Players eligible for DH slots can be designated as either 'DH' or 'UTIL', so the filter now explicitly checks for both possibilities rather than relying on a simple array inclusion check.

https://claude.ai/code/session_014AfAzenSGNf7aTnC5Hinun