### PR TITLE
Rename note feature to comment throughout codebase

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1154,7 +1154,7 @@ button[data-disabled] {
 .icon-btn:hover { opacity: 1; color: var(--brown); }
 .icon-btn.highlight-btn.active { color: var(--gold); opacity: 1; }
 .icon-btn.ignore-btn.active { color: var(--charcoal); opacity: 1; }
-.icon-btn.note-btn.active { color: var(--brown); opacity: 0.9; }
+.icon-btn.comment-btn.active { color: var(--brown); opacity: 0.9; }
 
 /* Settings button in controls bar */
 .gear-btn {

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -18,10 +18,9 @@ const HighlightIcon = () => (
     </svg>
 )
 
-const NoteIcon = () => (
+const CommentIcon = () => (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <line x1="18" y1="2" x2="22" y2="6"/>
-        <path d="M7.5 20.5 19 9l-4-4L3.5 16.5 2 22z"/>
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
     </svg>
 )
 
@@ -153,11 +152,11 @@ const PlayerItem = (props) => {
                     <div className="actions-wrapper">
                         {notesEditable && (
                             <button
-                                className={`icon-btn note-btn${(hasNote || showNote) ? ' active' : ''}`}
+                                className={`icon-btn comment-btn${(hasNote || showNote) ? ' active' : ''}`}
                                 onClick={onToggleNote}
-                                title={showNote ? 'Hide note' : 'Add note'}
+                                title={showNote ? 'Hide comment' : 'Add comment'}
                             >
-                                <NoteIcon />
+                                <CommentIcon />
                             </button>
                         )}
                         <button


### PR DESCRIPTION
## Summary
This PR renames the "note" feature to "comment" across the PlayerItem component and related styles for improved clarity and consistency in terminology.

## Key Changes
- Renamed `NoteIcon` component to `CommentIcon` with updated SVG path to use a comment bubble icon instead of a note/pencil icon
- Updated button className from `note-btn` to `comment-btn`
- Updated button title text from "Add note"/"Hide note" to "Add comment"/"Hide comment"
- Updated CSS selector from `.icon-btn.note-btn.active` to `.icon-btn.comment-btn.active`

## Implementation Details
The icon SVG was also updated to better represent a comment/chat bubble (showing a message box with a tail) rather than the previous note/pencil icon design. This visual change aligns with the semantic rename from "note" to "comment" and provides clearer UX intent.

https://claude.ai/code/session_01PoowpqiuVTiTGmEaAqBwi9