### PR TITLE
Add FantasyPros ECR rankings integration

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1052,6 +1052,23 @@ button[data-disabled] {
   width: 44px;
 }
 
+/* Source rank cells (ESPN, FPRO) */
+.rank-source-header {
+  font-size: 0.7rem;
+  text-align: center;
+  width: 44px;
+  white-space: nowrap;
+}
+
+.rank-source-cell {
+  text-align: center;
+  font-size: 0.8rem;
+  font-weight: 500;
+  width: 44px;
+  white-space: nowrap;
+  color: var(--brown);
+}
+
 /* ADP cell */
 .adp-cell {
   white-space: nowrap;
@@ -1686,6 +1703,29 @@ button {
   font-size: 0.875rem;
   margin-bottom: 0.5rem;
   padding: 0.25rem 0.5rem;
+}
+
+.player-card-ranks {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.rank-badge {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+}
+
+.rank-badge-label {
+  color: var(--greybrown);
+  font-weight: 500;
+}
+
+.rank-badge-value {
+  color: var(--brown);
+  font-weight: 700;
 }
 
 .player-card-stats {

--- a/client/src/components/PlayerList/PlayerCard.tsx
+++ b/client/src/components/PlayerList/PlayerCard.tsx
@@ -59,10 +59,24 @@ const PlayerCard = ({ playerId, onClose }) => {
                         </div>
                         {player.averageDraftPosition && (
                             <div className="adp">
-                                <span className="adp-label">Average Draft Position:</span> 
+                                <span className="adp-label">Average Draft Position:</span>
                                 <span className="adp-value">{Math.round(player.averageDraftPosition * 10) / 10}</span>
                             </div>
                         )}
+                        <div className="player-card-ranks">
+                            {player.espnRank && (
+                                <div className="rank-badge">
+                                    <span className="rank-badge-label">ESPN RK</span>
+                                    <span className="rank-badge-value">{player.espnRank}</span>
+                                </div>
+                            )}
+                            {player.fantasyProsRank && (
+                                <div className="rank-badge">
+                                    <span className="rank-badge-label">FPRO RK</span>
+                                    <span className="rank-badge-value">{player.fantasyProsRank}</span>
+                                </div>
+                            )}
+                        </div>
                     </div>
                 </div>
                 

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -143,6 +143,12 @@ const PlayerItem = (props) => {
                     )}
                 </div>
             </td>
+            <td className="rank-source-cell">
+                {player.espnRank ? player.espnRank : <span className="stat-neutral">—</span>}
+            </td>
+            <td className="rank-source-cell">
+                {player.fantasyProsRank ? player.fantasyProsRank : <span className="stat-neutral">—</span>}
+            </td>
             {columns.map(column => (
                 <td key={column.id} className="stat-cell">
                     {renderCellValue(player, column.id)}

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -142,6 +142,8 @@ const PlayerList = ({ editable }: any) => {
                             <th className="rank-header">#</th>
                             <th className="player-header">Player</th>
                             <th className="adp-header">ADP</th>
+                            <th className="rank-source-header">ESPN</th>
+                            <th className="rank-source-header">FPRO</th>
                             {columns.map(col => (
                                 <th
                                     key={col.id}

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -115,13 +115,16 @@ export const PITCHER_STATS = [
 ];
 
 // Data sources available for refresh
-export const VALID_DATA_SOURCES = ['teams', 'stats', 'projections', 'historical'] as const;
+export const VALID_DATA_SOURCES = ['teams', 'stats', 'projections', 'historical', 'fantasypros'] as const;
 
 // API URLs
 export const ESPN_TEAMS_URL = 'https://site.web.api.espn.com/apis/site/v2/teams?region=us&lang=en&leagues=mlb';
 export const ESPN_PLAYERS_URL = 'https://lm-api-reads.fantasy.espn.com/apis/v3/games/flb/seasons/2026/segments/0/leagues/3850?view=kona_player_info';
 export const FANGRAPHS_PROJECTIONS_URL = 'https://www.fangraphs.com/api/projections';
 export const FANGRAPHS_LEADERS_URL = 'https://www.fangraphs.com/api/leaders/major-league/data';
+
+// FantasyPros URL
+export const FANTASYPROS_RANKINGS_URL = 'https://www.fantasypros.com/mlb/rankings/overall.php';
 
 // Current season for data fetching
 export const CURRENT_SEASON = 2026;

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -21,6 +21,7 @@ import {
 } from '../services/storage.ts';
 import { fetch_teams_and_divisions, fetch_player_stats } from '../services/espn.ts';
 import { fetch_projections, build_player_projections, fetch_historical_stats } from '../services/fangraphs.ts';
+import { fetch_fantasypros_rankings, match_fantasypros_to_players } from '../services/fantasypros.ts';
 import { format_player_stats, format_projections, format_position_eligibility } from '../utils/formatters.ts';
 
 const admin_router = new Hono();
@@ -33,12 +34,14 @@ function build_player_store(
     player_details: PlayerDetails[],
     stats: Record<number, any>,
     projections: Record<number, any>,
-    historical_stats: Record<number, any>
+    historical_stats: Record<number, any>,
+    fantasypros_ranks: Record<number, { rank: number; adp: number | null }>
 ): Player[] {
     const players: Player[] = player_details.map(player => {
         const current_stats = format_player_stats(stats[player.id], player.eligible_slots);
         const historical = historical_stats[player.id] || {};
         const merged_stats = { ...current_stats, ...historical };
+        const fp_data = fantasypros_ranks[player.id];
 
         return {
             id: player.id,
@@ -56,6 +59,8 @@ function build_player_store(
             injuryStatus: player.injury_status || null,
             age: player.age || null,
             birthDate: player.birth_date || null,
+            espnRank: player.espn_rank || null,
+            fantasyProsRank: fp_data?.rank || null,
         };
     });
 
@@ -126,6 +131,23 @@ async function refresh_projections(
 }
 
 /**
+ * Refresh FantasyPros ECR rankings
+ */
+async function refresh_fantasypros(
+    player_details: PlayerDetails[]
+): Promise<Record<number, { rank: number; adp: number | null }>> {
+    try {
+        const fp_players = await fetch_fantasypros_rankings();
+        const matched = match_fantasypros_to_players(fp_players, player_details);
+        console.log(`FantasyPros: fetched ${fp_players.length} rankings, matched ${Object.keys(matched).length} players.`);
+        return matched;
+    } catch (error) {
+        console.error('Failed to fetch FantasyPros data:', error);
+        return {};
+    }
+}
+
+/**
  * GET /admin/refresh
  * Manually trigger a data refresh
  */
@@ -191,13 +213,23 @@ admin_router.get('/refresh', async (c) => {
 
     console.log(`Projections found: ${Object.keys(projections).length}`);
 
+    // Refresh FantasyPros rankings
+    let fantasypros_ranks: Record<number, { rank: number; adp: number | null }> = {};
+
+    if (sources_to_update.includes('fantasypros')) {
+        fantasypros_ranks = await refresh_fantasypros(player_details_array);
+    }
+
+    console.log(`FantasyPros ranks matched: ${Object.keys(fantasypros_ranks).length}`);
+
     // Build and store custom player objects
     const players = build_player_store(
         teams,
         player_details_array,
         stats,
         projections,
-        historical_stats
+        historical_stats,
+        fantasypros_ranks
     );
 
     await store_players(players);

--- a/server/services/espn.ts
+++ b/server/services/espn.ts
@@ -138,5 +138,6 @@ function extract_player_details(espn_player: any): PlayerDetails {
         percent_change: player.ownership?.percentChange || null,
         birth_date: player.dateOfBirth || null,
         age: calculate_age(player.dateOfBirth),
+        espn_rank: player.draftRanksByRankType?.STANDARD?.rank || null,
     };
 }

--- a/server/services/fantasypros.ts
+++ b/server/services/fantasypros.ts
@@ -1,0 +1,155 @@
+/**
+ * FantasyPros data fetching functions
+ * Fetches ECR (Expert Consensus Rankings) and ADP data
+ */
+
+import type { PlayerDetails } from '../types.ts';
+import { FANTASYPROS_RANKINGS_URL } from '../constants.ts';
+import { replace_accented_characters } from '../utils/formatters.ts';
+
+export interface FantasyProsPlayer {
+    rank: number;
+    name: string;
+    team: string;
+    position: string;
+    adp: number | null;
+}
+
+/**
+ * Fetch ECR rankings from FantasyPros
+ * Parses the HTML page to extract embedded ranking data
+ */
+export async function fetch_fantasypros_rankings(): Promise<FantasyProsPlayer[]> {
+    const response = await fetch(FANTASYPROS_RANKINGS_URL, {
+        headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Failed to fetch FantasyPros rankings: ${response.status}`);
+    }
+
+    const html = await response.text();
+    return parse_fantasypros_html(html);
+}
+
+/**
+ * Parse FantasyPros HTML page to extract ranking data
+ * Looks for embedded ECR data in script tags first, then falls back to table parsing
+ */
+function parse_fantasypros_html(html: string): FantasyProsPlayer[] {
+    // Try to find embedded ecrData JSON in script tags
+    const ecr_match = html.match(/var\s+ecrData\s*=\s*({[\s\S]*?});/);
+    if (ecr_match) {
+        try {
+            const ecr_data = JSON.parse(ecr_match[1]);
+            if (ecr_data.players && Array.isArray(ecr_data.players)) {
+                return ecr_data.players.map((p: any) => ({
+                    rank: p.rank_ecr || p.rank || 0,
+                    name: p.player_name || p.name || '',
+                    team: p.player_team_id || p.team || '',
+                    position: p.player_position_id || p.pos || '',
+                    adp: p.adp ? parseFloat(p.adp) : null,
+                }));
+            }
+        } catch {
+            console.warn('Failed to parse ecrData JSON, falling back to table parsing');
+        }
+    }
+
+    // Fallback: parse the HTML table rows
+    return parse_ranking_table(html);
+}
+
+/**
+ * Parse ranking data from an HTML table
+ */
+function parse_ranking_table(html: string): FantasyProsPlayer[] {
+    const players: FantasyProsPlayer[] = [];
+
+    // Match table rows with ranking data
+    // FantasyPros tables typically have: Rank, Player Name, Team, Position(s), ADP
+    const row_regex = /<tr[^>]*class="[^"]*mpb-player[^"]*"[^>]*>[\s\S]*?<\/tr>/gi;
+    const rows = html.match(row_regex) || [];
+
+    for (const row of rows) {
+        // Extract cells
+        const cells = row.match(/<td[^>]*>([\s\S]*?)<\/td>/gi) || [];
+        if (cells.length < 3) continue;
+
+        const strip_html = (s: string) => s.replace(/<[^>]+>/g, '').trim();
+
+        const rank_text = strip_html(cells[0]);
+        const rank = parseInt(rank_text);
+        if (isNaN(rank)) continue;
+
+        // Player name is usually in the second cell, possibly wrapped in an anchor tag
+        const name_match = cells[1].match(/<a[^>]*fp-player-name="([^"]+)"/) ||
+                          cells[1].match(/<a[^>]*>([^<]+)<\/a>/);
+        const name = name_match ? name_match[1].trim() : strip_html(cells[1]);
+
+        if (!name) continue;
+
+        // Find ADP - usually the last numeric cell
+        let adp: number | null = null;
+        for (let i = cells.length - 1; i >= 2; i--) {
+            const val = parseFloat(strip_html(cells[i]));
+            if (!isNaN(val) && val > 0 && val < 1000) {
+                adp = val;
+                break;
+            }
+        }
+
+        // Position and team from intermediate cells
+        const position = cells.length > 3 ? strip_html(cells[3]) : '';
+        const team = cells.length > 2 ? strip_html(cells[2]) : '';
+
+        players.push({ rank, name, team, position, adp });
+    }
+
+    return players;
+}
+
+/**
+ * Match FantasyPros players to our player details by name
+ * Returns a map of ESPN player ID -> { rank, adp }
+ */
+export function match_fantasypros_to_players(
+    fp_players: FantasyProsPlayer[],
+    player_details: PlayerDetails[]
+): Record<number, { rank: number; adp: number | null }> {
+    const result: Record<number, { rank: number; adp: number | null }> = {};
+
+    // Build a name lookup for our players
+    const name_to_player = new Map<string, PlayerDetails>();
+    const lastname_firstname_to_player = new Map<string, PlayerDetails>();
+
+    for (const player of player_details) {
+        const normalized = replace_accented_characters(player.full_name).toLowerCase();
+        name_to_player.set(normalized, player);
+
+        // Also try "LastName FirstName" format
+        const reversed = `${replace_accented_characters(player.last_name)} ${replace_accented_characters(player.first_name)}`.toLowerCase();
+        lastname_firstname_to_player.set(reversed, player);
+    }
+
+    for (const fp of fp_players) {
+        const normalized_name = replace_accented_characters(fp.name).toLowerCase();
+
+        let matched = name_to_player.get(normalized_name);
+        if (!matched) {
+            matched = lastname_firstname_to_player.get(normalized_name);
+        }
+
+        if (matched) {
+            result[matched.id] = {
+                rank: fp.rank,
+                adp: fp.adp,
+            };
+        }
+    }
+
+    return result;
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -34,6 +34,8 @@ export interface Player {
     injuryStatus: string | null;
     age: number | null;
     birthDate: string | null;
+    espnRank: number | null;
+    fantasyProsRank: number | null;
 }
 
 // Note: Ranking uses camelCase for stored field names to maintain
@@ -67,6 +69,7 @@ export interface PlayerDetails {
     percent_change: number | null;
     birth_date: string | null;
     age: number | null;
+    espn_rank: number | null;
 }
 
 export interface PlayerData {


### PR DESCRIPTION
## Summary
Integrates FantasyPros Expert Consensus Rankings (ECR) data into the player ranking system, allowing users to view ECR and ADP data alongside ESPN rankings.

## Key Changes

- **New FantasyPros Service** (`server/services/fantasypros.ts`)
  - Fetches ECR rankings from FantasyPros website
  - Parses embedded JSON data from HTML with fallback to table parsing
  - Matches FantasyPros players to internal player database by normalized name
  - Handles accented character normalization for accurate matching

- **Admin Refresh Endpoint Updates** (`server/routes/admin.ts`)
  - Added `refresh_fantasypros()` function to fetch and match rankings
  - Integrated FantasyPros data into player store building
  - Added 'fantasypros' as a valid data source for manual refresh

- **Data Model Extensions**
  - Added `espnRank` and `fantasyProsRank` fields to `Player` type
  - Added `espn_rank` field to `PlayerDetails` type
  - Updated player store builder to populate ranking fields

- **UI Enhancements**
  - Added rank source columns to player list table (ESPN RK, FPRO RK)
  - Added rank badges to player card detail view
  - New CSS styles for rank source headers and cells with brown color scheme

- **Configuration Updates**
  - Added `FANTASYPROS_RANKINGS_URL` constant
  - Added 'fantasypros' to `VALID_DATA_SOURCES`

## Implementation Details

The FantasyPros integration uses a two-stage parsing approach:
1. First attempts to extract embedded `ecrData` JSON from script tags for reliable data
2. Falls back to HTML table parsing if JSON extraction fails, making it resilient to page structure changes

Player matching uses normalized names (lowercase, accented characters removed) and supports both "FirstName LastName" and "LastName FirstName" formats to handle various naming conventions in the source data.

https://claude.ai/code/session_01W77FigW5jFtSyzZX1GVu5X