### PR TITLE
Add expandable note rows and UI refinements to player list

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -67,6 +67,7 @@
   --brown: #855a25;
   --grey: #c4c4c4;
   --royal-blue: #0059f3;
+  --highlight-blue: #3b82f6;
   --forest: #00a238;
   
   /* Define colors to be used in different themes */
@@ -647,7 +648,6 @@ button[data-disabled] {
   align-items: center;
   gap: 0.65rem;
   height: var(--controls-height);
-  background: var(--soft-tan);
   border-bottom: 1.5px solid var(--tan-dark);
   margin: 0.5rem 0 0;
   padding: 0 0.5rem;
@@ -954,13 +954,13 @@ button[data-disabled] {
 .player-row td:last-child  { border-radius: 0 6px 6px 0; }
 
 .player-row.highlighted td {
-  box-shadow: inset 0 1.5px 0 0 var(--gold), inset 0 -1.5px 0 0 var(--gold);
+  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
 }
 .player-row.highlighted td:first-child {
-  box-shadow: inset 1.5px 1.5px 0 0 var(--gold), inset 0 -1.5px 0 0 var(--gold);
+  box-shadow: inset 1.5px 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
 }
 .player-row.highlighted td:last-child {
-  box-shadow: inset -1.5px 1.5px 0 0 var(--gold), inset 0 -1.5px 0 0 var(--gold);
+  box-shadow: inset -1.5px 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
 }
 .player-row.ignored td { opacity: 0.5; }
 
@@ -991,7 +991,7 @@ button[data-disabled] {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  min-width: 190px;
+  min-width: 150px;
 }
 
 .player-identity {
@@ -1045,6 +1045,24 @@ button[data-disabled] {
   margin: 0;
 }
 
+/* Note accordion row */
+.note-row .note-row-cell {
+  background: rgba(134, 122, 101, 0.08);
+  padding: 0.3rem 0.5rem 0.3rem 3.5rem !important;
+  border-radius: 0 0 6px 6px;
+}
+
+.note-row .player-note-input {
+  width: 100%;
+}
+
+/* Active state for toggle-all-notes button */
+.gear-btn.active {
+  background: rgba(134, 122, 101, 0.15);
+  color: var(--brown);
+  border-color: var(--greybrown);
+}
+
 /* Stat cell */
 .stat-cell {
   text-align: center;
@@ -1056,11 +1074,13 @@ button[data-disabled] {
 .adp-cell {
   white-space: nowrap;
   width: 1%;
+  text-align: center;
 }
 
 .adp-info {
   display: flex;
   align-items: center;
+  justify-content: center;
   gap: 0.4rem;
 }
 
@@ -1099,20 +1119,33 @@ button[data-disabled] {
   opacity: 1;
 }
 
-/* Always show actions for active (highlighted/ignored) states */
-.actions-wrapper:has(.active) {
-  opacity: 1;
-}
+/* Actions only show on hover — row styling already signals highlighted/ignored */
 
 /* Border-radius on the cell before actions (the visual row end) */
 .player-row td:has(+ .actions-cell) { border-radius: 0 6px 6px 0; }
 
-/* Highlighted border on the cell before actions */
+/* Highlighted border on the cell before actions — close the right edge when actions hidden */
 .player-row.highlighted td:has(+ .actions-cell) {
-  box-shadow: inset -1.5px 1.5px 0 0 var(--gold), inset 0 -1.5px 0 0 var(--gold);
+  box-shadow: inset -1.5px 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
 }
 .player-row.highlighted td.actions-cell {
   box-shadow: none;
+}
+
+/* When hovered, extend the highlight border over the actions wrapper */
+.player-row.highlighted:hover td:has(+ .actions-cell) {
+  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
+}
+.player-row.highlighted .actions-wrapper {
+  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset -1.5px 0 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
+  border-radius: 0 6px 6px 0;
+}
+.draggable-item.highlighted:hover td:has(+ .actions-cell) {
+  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
+}
+.draggable-item.highlighted .actions-wrapper {
+  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset -1.5px 0 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
+  border-radius: 0 6px 6px 0;
 }
 
 .actions-header {
@@ -1152,7 +1185,7 @@ button[data-disabled] {
 }
 
 .icon-btn:hover { opacity: 1; color: var(--brown); }
-.icon-btn.highlight-btn.active { color: var(--gold); opacity: 1; }
+.icon-btn.highlight-btn.active { color: var(--highlight-blue); opacity: 1; }
 .icon-btn.ignore-btn.active { color: var(--charcoal); opacity: 1; }
 .icon-btn.note-btn.active { color: var(--brown); opacity: 0.9; }
 

--- a/client/src/components/FilterBar.tsx
+++ b/client/src/components/FilterBar.tsx
@@ -31,8 +31,14 @@ const GearIcon = () => (
     </svg>
 )
 
+const CommentIcon = () => (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+    </svg>
+)
+
 const FilterBar = (props) => {
-    const { posFilter, onPosChange, draftMode, searchQuery, onSearchChange } = props;
+    const { posFilter, onPosChange, draftMode, searchQuery, onSearchChange, allNotesExpanded, onToggleAllNotes } = props;
     const [showStatsModal, setShowStatsModal] = useState(false);
 
     return (
@@ -74,6 +80,13 @@ const FilterBar = (props) => {
 
             {!draftMode && (
                 <div className="controls-actions">
+                    <button
+                        className={`gear-btn${allNotesExpanded ? ' active' : ''}`}
+                        onClick={onToggleAllNotes}
+                        title={allNotesExpanded ? 'Collapse all notes' : 'Expand all notes'}
+                    >
+                        <CommentIcon />
+                    </button>
                     <button
                         className="gear-btn"
                         onClick={() => setShowStatsModal(true)}

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -1,4 +1,4 @@
-import {useContext, useState, useRef} from 'react'
+import {useContext, useState, useRef, useEffect} from 'react'
 import {StoreContext} from '~/data/store'
 import {DraftContext} from '~/data/draftContext'
 import {formatStatValue, evaluateStatQuality} from '~/features/stats'
@@ -26,17 +26,13 @@ const NoteIcon = () => (
 )
 
 const PlayerItem = (props) => {
-    const {playerId, playerRanking, editable, onNameClick, columns, rank} = props
-    const {players, teams, mode, ignorePlayer, highlightPlayer, updatePlayerNote, userRanking} = useContext(StoreContext);
+    const {playerId, playerRanking, editable, onNameClick, columns, rank, showNote, onToggleNote} = props
+    const {players, teams, mode, ignorePlayer, highlightPlayer, userRanking} = useContext(StoreContext);
     const {isMyTurn, draftPlayer} = useContext(DraftContext);
 
     const isDraftMode = mode === 'draft';
     const notesEditable = editable && (!userRanking?.isShared || !!userRanking?.pin);
     const hasNote = !!playerRanking?.note;
-
-    const [noteText, setNoteText] = useState(playerRanking?.note || '');
-    const [showNote, setShowNote] = useState(hasNote);
-    const noteRef = useRef<HTMLTextAreaElement>(null);
 
     const player = players[playerId]
     const projections = player.projections
@@ -76,15 +72,6 @@ const PlayerItem = (props) => {
     const onIgnore = () => ignorePlayer(playerId)
     const onDraft = () => draftPlayer(playerId)
 
-    const onToggleNote = () => {
-        const next = !showNote;
-        setShowNote(next);
-        if (next) {
-            // Focus the textarea on the next render tick
-            setTimeout(() => noteRef.current?.focus(), 0);
-        }
-    }
-
     const isHighlighted = !!playerRanking?.highlight
     const isIgnored = !!playerRanking?.ignore
 
@@ -107,27 +94,12 @@ const PlayerItem = (props) => {
                             >{position}</span>
                         ))}
                     </div>
-                    {notesEditable && showNote && (
-                        <textarea
-                            ref={noteRef}
-                            className="player-note-input"
-                            placeholder="Add a note…"
-                            value={noteText}
-                            onChange={(e) => setNoteText(e.target.value)}
-                            onBlur={() => updatePlayerNote(playerId, noteText)}
-                            rows={1}
-                        />
-                    )}
-                    {!notesEditable && hasNote && (
-                        <p className="player-note-text">{playerRanking.note}</p>
-                    )}
                 </div>
             </td>
             <td className="adp-cell">
                 <div className="adp-info">
                     {player.averageDraftPosition && (
                         <div className="adp">
-                            <span className="adp-label">ADP</span>
                             <span className="adp-value">{Math.round(player.averageDraftPosition * 10) / 10}</span>
                             {player.adpChange && (
                                 <span className={`adp-change ${player.adpChange > 0 ? 'positive' : 'negative'}`}>
@@ -190,4 +162,38 @@ const PlayerItem = (props) => {
     )
 }
 
+const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable }) => {
+    const {updatePlayerNote, userRanking} = useContext(StoreContext);
+    const notesEditable = editable && (!userRanking?.isShared || !!userRanking?.pin);
+    const [noteText, setNoteText] = useState(playerRanking?.note || '');
+    const noteRef = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        if (notesEditable) {
+            setTimeout(() => noteRef.current?.focus(), 0);
+        }
+    }, []);
+
+    return (
+        <tr className="note-row">
+            <td colSpan={colSpan} className="note-row-cell">
+                {notesEditable ? (
+                    <textarea
+                        ref={noteRef}
+                        className="player-note-input"
+                        placeholder="Add a note…"
+                        value={noteText}
+                        onChange={(e) => setNoteText(e.target.value)}
+                        onBlur={() => updatePlayerNote(playerId, noteText)}
+                        rows={1}
+                    />
+                ) : (
+                    <p className="player-note-text">{playerRanking?.note}</p>
+                )}
+            </td>
+        </tr>
+    )
+}
+
+export { PlayerNoteRow }
 export default PlayerItem

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -16,7 +16,7 @@ import {
 import { restrictToVerticalAxis } from '@dnd-kit/modifiers'
 import FilterBar from '~/components/FilterBar'
 import DraggableItem from './DraggableItem'
-import PlayerItem from './PlayerItem'
+import PlayerItem, {PlayerNoteRow} from './PlayerItem'
 import PlayerCard from './PlayerCard'
 import Toast from '~/components/Toast'
 import {StoreContext} from '~/data/store'
@@ -35,6 +35,8 @@ const PlayerList = ({ editable }: any) => {
     const [sortColumn, setSortColumn] = useState<string | null>(null);
     const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
     const [searchQuery, setSearchQuery] = useState('');
+    const [expandedNotes, setExpandedNotes] = useState<Record<string, boolean>>({});
+    const [allNotesExpanded, setAllNotesExpanded] = useState(false);
 
     const isDraftMode = mode === 'draft';
     const draftedPlayerIds = isDraftMode ? Object.values(draftedPlayers) : [];
@@ -117,6 +119,29 @@ const PlayerList = ({ editable }: any) => {
         })
         : rankedBeforeSort;
 
+    const toggleNote = (playerId: string) => {
+        setExpandedNotes(prev => ({ ...prev, [playerId]: !prev[playerId] }));
+    }
+
+    const toggleAllNotes = () => {
+        const next = !allNotesExpanded;
+        setAllNotesExpanded(next);
+        if (next) {
+            const all: Record<string, boolean> = {};
+            displayedPlayerIds.forEach(id => { all[id] = true; });
+            setExpandedNotes(all);
+        } else {
+            setExpandedNotes({});
+        }
+    }
+
+    const isNoteExpanded = (playerId: string) => {
+        return !!expandedNotes[playerId];
+    }
+
+    // Total columns for note row colSpan: rank + player + adp + stats + actions
+    const totalColumns = 3 + columns.length + (editable ? 1 : 0);
+
     return (
         <>
             <FilterBar
@@ -125,6 +150,8 @@ const PlayerList = ({ editable }: any) => {
                 draftMode={isDraftMode}
                 searchQuery={searchQuery}
                 onSearchChange={setSearchQuery}
+                allNotesExpanded={allNotesExpanded}
+                onToggleAllNotes={toggleAllNotes}
             />
 
             <UnsavedChangesPrompt rankedPlayerIds={rankedPlayerIds} />
@@ -171,27 +198,53 @@ const PlayerList = ({ editable }: any) => {
                                 const playerRanking = ranking.players[playerId];
                                 const rowClass = `player-row${playerRanking?.highlight ? ' highlighted' : playerRanking?.ignore ? ' ignored' : ''}`;
 
+                                const noteVisible = isNoteExpanded(playerId);
+
                                 return editable ? (
-                                    <DraggableItem key={playerId} id={playerId} className={rowClass}>
-                                        <PlayerItem
-                                            playerId={playerId}
-                                            rank={rank}
-                                            columns={columns}
-                                            playerRanking={playerRanking}
-                                            editable
-                                            onNameClick={() => setShowCardForPlayerId(playerId)}
-                                        />
-                                    </DraggableItem>
+                                    <React.Fragment key={playerId}>
+                                        <DraggableItem id={playerId} className={rowClass}>
+                                            <PlayerItem
+                                                playerId={playerId}
+                                                rank={rank}
+                                                columns={columns}
+                                                playerRanking={playerRanking}
+                                                editable
+                                                onNameClick={() => setShowCardForPlayerId(playerId)}
+                                                showNote={noteVisible}
+                                                onToggleNote={() => toggleNote(playerId)}
+                                            />
+                                        </DraggableItem>
+                                        {noteVisible && (
+                                            <PlayerNoteRow
+                                                playerId={playerId}
+                                                playerRanking={playerRanking}
+                                                colSpan={totalColumns}
+                                                editable={editable}
+                                            />
+                                        )}
+                                    </React.Fragment>
                                 ) : (
-                                    <tr key={playerId} className={rowClass}>
-                                        <PlayerItem
-                                            playerId={playerId}
-                                            rank={rank}
-                                            columns={columns}
-                                            playerRanking={playerRanking}
-                                            onNameClick={() => setShowCardForPlayerId(playerId)}
-                                        />
-                                    </tr>
+                                    <React.Fragment key={playerId}>
+                                        <tr className={rowClass}>
+                                            <PlayerItem
+                                                playerId={playerId}
+                                                rank={rank}
+                                                columns={columns}
+                                                playerRanking={playerRanking}
+                                                onNameClick={() => setShowCardForPlayerId(playerId)}
+                                                showNote={noteVisible}
+                                                onToggleNote={() => toggleNote(playerId)}
+                                            />
+                                        </tr>
+                                        {noteVisible && (
+                                            <PlayerNoteRow
+                                                playerId={playerId}
+                                                playerRanking={playerRanking}
+                                                colSpan={totalColumns}
+                                                editable={editable}
+                                            />
+                                        )}
+                                    </React.Fragment>
                                 );
                             })}
                         </SortableContext>

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,90 @@
+# Design Updates Plan
+
+Based on the annotated screenshot, here are the 7 design changes to implement:
+
+---
+
+## 1. Remove background from controls bar, keep it on table header
+**Files:** `client/src/app.css` (~line 642-655)
+
+The `.player-controls` sticky toolbar currently has `background: var(--soft-tan)` which gives it the same tan background as the table. Remove this background so the controls float cleanly above the table, while keeping the `background: var(--soft-tan)` on `.player-table thead th` (line 925).
+
+- Remove `background: var(--soft-tan)` from `.player-controls`
+- Keep the sticky positioning and border-bottom intact
+
+---
+
+## 2. Narrow the search bar / distribute column widths more evenly
+**Files:** `client/src/app.css` (~line 685-702)
+
+The search input is currently `width: 210px` (expands to `265px` on focus). The player column also has `min-width: 190px`. The annotation says the player column width is fine but the overall columns should distribute more evenly.
+
+- Reduce `.search-input` width from `210px` to ~`160px` and focus width from `265px` to ~`210px`
+- This naturally allows more room for stat columns
+
+---
+
+## 3. Fix ADP column: center-align, remove redundant "ADP" label from cells
+**Files:** `client/src/components/PlayerList/PlayerItem.tsx` (lines 126-145), `client/src/app.css` (lines 1055-1065, 1215-1231)
+
+Currently each cell shows "ADP 2.4" with an "ADP" label prefix, and the column header already says "ADP". The annotation says this is redundant and the column should be center-aligned.
+
+- Remove the `<span className="adp-label">ADP</span>` from `PlayerItem.tsx` line 130
+- Center-align the `.adp-cell` content via `text-align: center`
+- The ADP value display should just show the number (e.g., "2.4" not "ADP 2.4")
+
+---
+
+## 4. Comments as expandable accordion rows
+**Files:** `client/src/components/PlayerList/PlayerItem.tsx`, `client/src/components/PlayerList/PlayerList.tsx`, `client/src/app.css`
+
+Currently notes/comments are rendered inline inside the player identity cell, which expands the row height. The annotation says comments should be in an accordion: an icon triggers expansion, and the comment spans the full width of the row underneath.
+
+- Keep the note toggle icon button in the actions area
+- When toggled, render the note as a separate `<tr>` below the player row that spans all columns (`colSpan`)
+- The note row should not affect the main player row height
+- Move the note textarea out of `.player-identity-cell` and into a full-width expandable row
+- This requires changes to how `PlayerItem` communicates note visibility — likely lift `showNote` state up to `PlayerList` or return the note row as a sibling `<tr>`
+
+---
+
+## 5. Change highlight border from gold to blue
+**Files:** `client/src/app.css` (lines 956-963, 1111-1113)
+
+The annotation says highlighted players should use a blue border instead of gold.
+
+- Add a CSS variable like `--highlight-blue: #3b82f6` (or use existing `--navy`)
+- Replace `var(--gold)` with the new blue variable in all `.player-row.highlighted` box-shadow rules (lines 957, 960, 963, 1112)
+- Update `.icon-btn.highlight-btn.active` color to match (line 1155)
+
+---
+
+## 6. Action buttons: show only on hover, not when active
+**Files:** `client/src/app.css` (lines 1097-1105)
+
+Currently the actions wrapper shows on hover AND stays visible when any button has `.active` class (via `:has(.active)`). The annotation says buttons should only show on hover since the row itself already signals highlighted/ignored state visually.
+
+- Remove the `.actions-wrapper:has(.active)` rule (lines 1103-1105) so actions only appear on hover
+
+---
+
+## 7. Extend highlight border over the actions area
+**Files:** `client/src/app.css` (lines 1067-1116)
+
+The annotation notes that the highlight border doesn't extend over the actions area when buttons are displayed. Currently `.actions-cell` has `background: none !important` and `box-shadow: none`, which breaks the border continuity.
+
+- When the row is highlighted and hovered, the actions wrapper should also show the highlight border
+- Update `.player-row.highlighted .actions-wrapper` to include matching top/bottom border styling
+- Ensure the gradient background of `.actions-wrapper` doesn't clip the border
+
+---
+
+## 8. Add "Toggle all comments" button in the header
+**Files:** `client/src/components/FilterBar.tsx`, `client/src/components/PlayerList/PlayerList.tsx`
+
+The annotation shows a speech-bubble icon button in the header controls area (next to the gear/Stats button) that toggles all comments open/closed.
+
+- Add a comment/chat icon button to `FilterBar.tsx` in the `.controls-actions` area
+- Add `allNotesExpanded` state in `PlayerList` (or pass down as prop)
+- The button toggles all player notes open/closed globally
+- This pairs with change #4 (accordion comments) — when toggled on, all note rows expand

--- a/plan.md
+++ b/plan.md
@@ -14,13 +14,13 @@ The `.player-controls` sticky toolbar currently has `background: var(--soft-tan)
 
 ---
 
-## 2. Narrow the search bar / distribute column widths more evenly
-**Files:** `client/src/app.css` (~line 685-702)
+## 2. Narrow the Player column / distribute column widths more evenly
+**Files:** `client/src/app.css` (~line 990-995)
 
-The search input is currently `width: 210px` (expands to `265px` on focus). The player column also has `min-width: 190px`. The annotation says the player column width is fine but the overall columns should distribute more evenly.
+The Player column currently has `min-width: 190px` on `.player-identity-cell`, making it wider than necessary and squeezing stat columns. The search bar width is fine as-is.
 
-- Reduce `.search-input` width from `210px` to ~`160px` and focus width from `265px` to ~`210px`
-- This naturally allows more room for stat columns
+- Reduce `.player-identity-cell` `min-width` from `190px` to a smaller value (e.g., ~`150px`)
+- This gives stat columns more breathing room and distributes widths more evenly
 
 ---
 


### PR DESCRIPTION
## Summary
This PR implements expandable accordion-style note rows for player comments and applies several UI refinements to the player list table, including highlight color changes, column width adjustments, and improved action button visibility.

## Key Changes

### Note Accordion System
- Extracted note display logic from `PlayerItem` into a new `PlayerNoteRow` component that renders as a separate table row
- Added state management in `PlayerList` to track expanded/collapsed state per player (`expandedNotes`) and global toggle state (`allNotesExpanded`)
- Implemented `toggleNote()` and `toggleAllNotes()` functions to manage note visibility
- Notes now span the full table width via `colSpan` and appear below the player row without affecting row height
- Added "Toggle all notes" button in `FilterBar` with a comment icon

### UI Refinements
- **Highlight color**: Changed highlight border from gold to blue (`--highlight-blue: #3b82f6`) across all highlighted row states
- **Column widths**: Reduced `.player-identity-cell` min-width from 190px to 150px for better distribution
- **ADP column**: Center-aligned the ADP cell and removed redundant "ADP" label prefix from values
- **Controls bar**: Removed background color from `.player-controls` so it floats cleanly above the table
- **Action buttons**: Removed the `:has(.active)` rule so buttons only appear on hover (row styling already signals state)
- **Highlight border extension**: Extended highlight border over the actions area on hover with proper box-shadow styling

### Component Updates
- `PlayerItem`: Removed local note state and textarea rendering; now accepts `showNote` and `onToggleNote` props
- `PlayerList`: Lifted note state management and added note row rendering logic with proper `colSpan` calculation
- `FilterBar`: Added comment icon button for toggling all notes globally

### CSS Additions
- New `.note-row` and `.note-row-cell` styles for the accordion row appearance
- Updated highlight border styling to use blue color variable
- Added active state styling for the toggle-all-notes button
- Improved actions wrapper border styling for highlighted rows on hover

https://claude.ai/code/session_017wZ7VeKUi7bBFt5FWV6ViQ