### PR TITLE
Redesign player injury status display and improve player info layout

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1302,9 +1302,15 @@ button[data-disabled] {
   font-weight: 600;
 }
 
-.player-position-list {
-  color: var(--greybrown);
-}
+.player-pos[data-pos="SP"] { color: var(--c-sp); }
+.player-pos[data-pos="RP"] { color: var(--c-rp); }
+.player-pos[data-pos="C"] { color: var(--c-c); }
+.player-pos[data-pos="1B"] { color: var(--c-1b); }
+.player-pos[data-pos="2B"] { color: var(--c-2b); }
+.player-pos[data-pos="3B"] { color: var(--c-3b); }
+.player-pos[data-pos="SS"] { color: var(--c-ss); }
+.player-pos[data-pos="OF"] { color: var(--c-of); }
+.player-pos[data-pos="DH"] { color: var(--c-dh); }
 
 .player-name {
   cursor: pointer;

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1277,13 +1277,33 @@ button[data-disabled] {
   color: var(--notification-red);
 }
 
-.injury-status {
-  padding: 0.1rem 0.25rem;
-  border-radius: 3px;
-  font-size: 0.7rem;
+.player-name-row {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.injury-designation {
+  font-size: 0.65rem;
   font-weight: bold;
-  background-color: rgba(255, 84, 74, 0.1);
   color: var(--notification-red);
+}
+
+.player-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  color: var(--greybrown);
+  font-size: 0.7rem;
+  line-height: 1.2;
+}
+
+.player-team-abbrev {
+  font-weight: 600;
+}
+
+.player-position-list {
+  color: var(--greybrown);
 }
 
 .player-name {

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -5,6 +5,23 @@ import {formatStatValue, evaluateStatQuality} from '~/features/stats'
 
 const EXCLUDED_POSITIONS = ['1B/3B', '2B/SS', 'P', 'UTIL']
 
+const INJURY_LABELS = {
+    'DAY_TO_DAY': 'DTD',
+    'OUT': 'O',
+    'SEVEN_DAY_DL': 'IL7',
+    'TEN_DAY_DL': 'IL10',
+    'FIFTEEN_DAY_DL': 'IL15',
+    'SIXTY_DAY_DL': 'IL60',
+    'SUSPENSION': 'SUSP',
+    'PATERNITY': 'PAT',
+    'BEREAVEMENT': 'BRV',
+}
+
+const getInjuryLabel = (status) => {
+    if (!status || status === 'ACTIVE') return null
+    return INJURY_LABELS[status] || status
+}
+
 const IgnoreIcon = () => (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
         <circle cx="12" cy="12" r="10"/>
@@ -65,7 +82,9 @@ const PlayerItem = (props) => {
         return <span className={className}>{formattedValue}</span>;
     }
 
-    const teamLogo = teams[player.team_id].logo?.href
+    const team = teams[player.team_id]
+    const teamLogo = team.logo?.href
+    const injuryLabel = getInjuryLabel(player.injuryStatus)
 
     const onHighlight = () => highlightPlayer(playerId)
     const onIgnore = () => ignorePlayer(playerId)
@@ -83,15 +102,17 @@ const PlayerItem = (props) => {
                     <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="72" onError={(e) => { (e.target as HTMLImageElement).src = '/assets/images/player-fallback.png'; }} />
                 </div>
                 <div className="player-identity">
-                    <span className="player-name" onClick={onNameClick}>{player.name}</span>
-                    <div className="player-positions small">
-                        {positions.map(position => (
-                            <span
-                                key={position}
-                                className="position-chip small"
-                                data-pos={position}
-                            >{position}</span>
-                        ))}
+                    <div className="player-name-row">
+                        <span className="player-name" onClick={onNameClick}>{player.name}</span>
+                        {injuryLabel && (
+                            <span className="injury-designation">{injuryLabel}</span>
+                        )}
+                    </div>
+                    <div className="player-meta small">
+                        <span className="player-team-abbrev">{team.abbrev}</span>
+                        <span className="player-position-list">
+                            {positions.join(', ')}
+                        </span>
                     </div>
                 </div>
             </td>
@@ -105,11 +126,6 @@ const PlayerItem = (props) => {
                                     ({player.adpChange > 0 ? '+' : ''}{player.adpChange}%)
                                 </span>
                             )}
-                        </div>
-                    )}
-                    {player.injuryStatus && player.injuryStatus !== "ACTIVE" && (
-                        <div className="injury-status">
-                            {player.injuryStatus === "DAY_TO_DAY" ? "D2D" : player.injuryStatus}
                         </div>
                     )}
                 </div>

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -111,7 +111,12 @@ const PlayerItem = (props) => {
                     <div className="player-meta small">
                         <span className="player-team-abbrev">{team.abbrev}</span>
                         <span className="player-position-list">
-                            {positions.join(', ')}
+                            {positions.map((position, i) => (
+                                <span key={position}>
+                                    {i > 0 && ', '}
+                                    <span className="player-pos" data-pos={position}>{position}</span>
+                                </span>
+                            ))}
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
Refactored the player list item component to improve the display of injury status information and reorganize player metadata presentation. The injury status is now shown inline with the player name using standardized abbreviations, and player positions are displayed as a comma-separated list alongside team abbreviation.

## Key Changes
- **Injury Status Display**: Moved injury status from a separate badge below player info to an inline designation next to the player name, using standardized abbreviation labels (e.g., "DTD" for Day-to-Day, "IL10" for 10-Day IL)
- **New Injury Label Mapping**: Created `INJURY_LABELS` constant and `getInjuryLabel()` helper function to convert injury status codes to user-friendly abbreviations
- **Reorganized Player Metadata**: Restructured the player identity section to display:
  - Player name with inline injury designation (new `.player-name-row` layout)
  - Team abbreviation and position list on a second line (new `.player-meta` layout)
- **Position Display**: Changed from individual position chips to a comma-separated list format with color-coded positions
- **Styling Updates**: 
  - Replaced `.injury-status` styles with new `.injury-designation` (smaller, no background)
  - Added `.player-name-row` for flex layout of name and injury badge
  - Added `.player-meta` for team abbreviation and position list styling
  - Added position-specific color classes (`.player-pos[data-pos="..."]`) for visual differentiation

## Implementation Details
- The `getInjuryLabel()` function returns `null` for active players or missing status, preventing unnecessary rendering
- Team abbreviation is now extracted and reused from the team object
- Position rendering uses index-based comma insertion to avoid trailing separators
- All injury status codes are now handled consistently through the centralized mapping

https://claude.ai/code/session_019Jg6nk5XHqftBmooGWfqLS