### PR TITLE
Fix zebra striping with note rows and improve styling

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -945,8 +945,8 @@ button[data-disabled] {
   vertical-align: middle;
 }
 
-/* Zebra striping */
-.player-table tbody tr:nth-child(even) td {
+/* Zebra striping — class-based to handle note rows */
+.player-table tbody tr.even-row td {
   background: #e0d3b0;
 }
 
@@ -1045,12 +1045,24 @@ button[data-disabled] {
   margin: 0;
 }
 
-/* Note accordion row */
+/* Note accordion row — seamless with parent */
 .note-row .note-row-cell {
-  background: rgba(134, 122, 101, 0.08);
-  padding: 0.3rem 0.5rem 0.3rem 3.5rem !important;
+  background: var(--soft-tan);
+  padding: 0 0.5rem 0.3rem 3.5rem !important;
   border-radius: 0 0 6px 6px;
 }
+
+.note-row.even-row .note-row-cell {
+  background: #e0d3b0;
+}
+
+/* Remove bottom border-radius from player row when note row follows */
+.player-row:has(+ .note-row) td:first-child,
+.draggable-item:has(+ .note-row) td:first-child { border-radius: 6px 0 0 0; }
+.player-row:has(+ .note-row) td:last-child,
+.draggable-item:has(+ .note-row) td:last-child { border-radius: 0 6px 0 0; }
+.player-row:has(+ .note-row) td:has(+ .actions-cell),
+.draggable-item:has(+ .note-row) td:has(+ .actions-cell) { border-radius: 0; }
 
 .note-row .player-note-input {
   width: 100%;
@@ -1110,7 +1122,7 @@ button[data-disabled] {
   border-radius: 0 6px 6px 0;
 }
 
-.player-table tbody tr:nth-child(even) .actions-wrapper {
+.player-table tbody tr.even-row .actions-wrapper {
   background: linear-gradient(to right, transparent, #e0d3b0 30%);
 }
 

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -26,11 +26,10 @@ const CommentIcon = () => (
 
 const PlayerItem = (props) => {
     const {playerId, playerRanking, editable, onNameClick, columns, rank, showNote, onToggleNote} = props
-    const {players, teams, mode, ignorePlayer, highlightPlayer, userRanking} = useContext(StoreContext);
+    const {players, teams, mode, ignorePlayer, highlightPlayer} = useContext(StoreContext);
     const {isMyTurn, draftPlayer} = useContext(DraftContext);
 
     const isDraftMode = mode === 'draft';
-    const notesEditable = editable && (!userRanking?.isShared || !!userRanking?.pin);
     const hasNote = !!playerRanking?.note;
 
     const player = players[playerId]
@@ -122,15 +121,13 @@ const PlayerItem = (props) => {
             {editable && !isDraftMode && (
                 <td className="actions-cell">
                     <div className="actions-wrapper">
-                        {notesEditable && (
-                            <button
-                                className={`icon-btn comment-btn${(hasNote || showNote) ? ' active' : ''}`}
-                                onClick={onToggleNote}
-                                title={showNote ? 'Hide comment' : 'Add comment'}
-                            >
-                                <CommentIcon />
-                            </button>
-                        )}
+                        <button
+                            className={`icon-btn comment-btn${(hasNote || showNote) ? ' active' : ''}`}
+                            onClick={onToggleNote}
+                            title={showNote ? 'Hide comment' : 'Add comment'}
+                        >
+                            <CommentIcon />
+                        </button>
                         <button
                             className={`icon-btn ignore-btn${isIgnored ? ' active' : ''}`}
                             onClick={onIgnore}
@@ -161,7 +158,7 @@ const PlayerItem = (props) => {
     )
 }
 
-const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable }) => {
+const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable, isEven }) => {
     const {updatePlayerNote, userRanking} = useContext(StoreContext);
     const notesEditable = editable && (!userRanking?.isShared || !!userRanking?.pin);
     const [noteText, setNoteText] = useState(playerRanking?.note || '');
@@ -174,7 +171,7 @@ const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable }) => {
     }, []);
 
     return (
-        <tr className="note-row">
+        <tr className={`note-row${isEven ? ' even-row' : ''}`}>
             <td colSpan={colSpan} className="note-row-cell">
                 {notesEditable ? (
                     <textarea

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -132,7 +132,11 @@ const PlayerList = ({ editable }: any) => {
         setAllNotesExpanded(next);
         if (next) {
             const all: Record<string, boolean> = {};
-            displayedPlayerIds.forEach(id => { all[id] = true; });
+            displayedPlayerIds.forEach(id => {
+                if (ranking.players[id]?.note) {
+                    all[id] = true;
+                }
+            });
             setExpandedNotes(all);
         } else {
             setExpandedNotes({});
@@ -195,12 +199,13 @@ const PlayerList = ({ editable }: any) => {
                             items={rankedPlayerIds}
                             strategy={verticalListSortingStrategy}
                         >
-                            {displayedPlayerIds.map(playerId => {
+                            {displayedPlayerIds.map((playerId, visualIndex) => {
                                 // Rank = 1-based position in the pre-sort filtered list
                                 // (reflects live drag order and position-filtered context)
                                 const rank = rankedBeforeSort.indexOf(playerId) + 1;
                                 const playerRanking = ranking.players[playerId];
-                                const rowClass = `player-row${playerRanking?.highlight ? ' highlighted' : playerRanking?.ignore ? ' ignored' : ''}`;
+                                const isEven = visualIndex % 2 === 1;
+                                const rowClass = `player-row${isEven ? ' even-row' : ''}${playerRanking?.highlight ? ' highlighted' : playerRanking?.ignore ? ' ignored' : ''}`;
 
                                 const noteVisible = isNoteExpanded(playerId);
 
@@ -224,6 +229,7 @@ const PlayerList = ({ editable }: any) => {
                                                 playerRanking={playerRanking}
                                                 colSpan={totalColumns}
                                                 editable={editable}
+                                                isEven={isEven}
                                             />
                                         )}
                                     </React.Fragment>
@@ -246,6 +252,7 @@ const PlayerList = ({ editable }: any) => {
                                                 playerRanking={playerRanking}
                                                 colSpan={totalColumns}
                                                 editable={editable}
+                                                isEven={isEven}
                                             />
                                         )}
                                     </React.Fragment>


### PR DESCRIPTION
## Summary
This PR fixes zebra striping in the player table to properly account for note rows that appear between player rows. The previous implementation used CSS `:nth-child(even)` which didn't account for dynamically inserted note rows, causing misaligned striping. The solution switches to class-based striping and improves the visual integration of note rows with their parent player rows.

## Key Changes
- **Zebra striping refactor**: Changed from CSS `:nth-child(even)` selector to class-based `.even-row` to properly handle note rows that are inserted between player rows
- **Note row styling improvements**: 
  - Updated note row background to use CSS variable `--soft-tan` for consistency
  - Added matching background color for note rows when they follow even-numbered player rows
  - Adjusted padding to remove top padding for seamless visual integration
- **Border radius refinement**: Added CSS rules using `:has()` selector to adjust border-radius on player rows when followed by note rows, creating a seamless visual appearance
- **Component logic updates**:
  - Removed unused `userRanking` context variable from PlayerItem
  - Removed conditional rendering of comment button based on `notesEditable` (now always shown when editable)
  - Added `isEven` prop to PlayerNoteRow component to apply correct striping class
  - Updated PlayerList to track visual index and pass `isEven` flag to both player and note rows
  - Fixed "expand all notes" functionality to only expand rows that actually have notes

## Implementation Details
- The `visualIndex` is calculated from the mapped position in `displayedPlayerIds`, ensuring correct striping regardless of filtering or sorting
- Note rows now inherit the striping class from their parent player row's visual position
- The `:has()` selector is used to conditionally adjust border-radius, creating a unified appearance between player and note rows

https://claude.ai/code/session_01SL9xoEPvEGGZx5DTcgLh3J