### PR TITLE
Add vsADP column to player list with rank differential display

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1134,11 +1134,16 @@ button[data-disabled] {
   white-space: nowrap;
 }
 
-.vs-adp-positive {
+.vs-adp-gold {
+  color: var(--gold);
+  font-weight: 700;
+}
+
+.vs-adp-green {
   color: #2e7d32;
 }
 
-.vs-adp-negative {
+.vs-adp-red {
   color: #c62828;
 }
 

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1100,11 +1100,50 @@ button[data-disabled] {
   color: var(--brown);
 }
 
+/* Column group borders */
+.adp-header,
+.adp-cell {
+  border-left: 2px solid var(--tan-dark);
+}
+
+.vs-adp-header,
+.vs-adp-cell {
+  border-right: 2px solid var(--tan-dark);
+}
+
 /* ADP cell */
 .adp-cell {
   white-space: nowrap;
   width: 1%;
   text-align: center;
+}
+
+/* vsADP cell */
+.vs-adp-header {
+  font-size: 0.65rem;
+  text-align: center;
+  width: 44px;
+  white-space: nowrap;
+}
+
+.vs-adp-cell {
+  text-align: center;
+  font-size: 0.8rem;
+  font-weight: 600;
+  width: 44px;
+  white-space: nowrap;
+}
+
+.vs-adp-positive {
+  color: #2e7d32;
+}
+
+.vs-adp-negative {
+  color: #c62828;
+}
+
+.vs-adp-neutral {
+  color: var(--greybrown);
 }
 
 .adp-info {

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -140,6 +140,15 @@ const PlayerItem = (props) => {
             <td className="rank-source-cell">
                 {player.fantasyProsRank ? player.fantasyProsRank : <span className="stat-neutral">—</span>}
             </td>
+            <td className="vs-adp-cell">
+                {player.averageDraftPosition ? (() => {
+                    const adpRound = Math.round(player.averageDraftPosition);
+                    const diff = adpRound - rank;
+                    if (diff === 0) return <span className="vs-adp-neutral">0</span>;
+                    const className = diff > 0 ? 'vs-adp-positive' : 'vs-adp-negative';
+                    return <span className={className}>{diff > 0 ? '+' : ''}{diff}</span>;
+                })() : <span className="stat-neutral">—</span>}
+            </td>
             {columns.map(column => (
                 <td key={column.id} className="stat-cell">
                     {renderCellValue(player, column.id)}

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -144,8 +144,10 @@ const PlayerItem = (props) => {
                 {player.averageDraftPosition ? (() => {
                     const adpRound = Math.round(player.averageDraftPosition);
                     const diff = adpRound - rank;
-                    if (diff === 0) return <span className="vs-adp-neutral">0</span>;
-                    const className = diff > 0 ? 'vs-adp-positive' : 'vs-adp-negative';
+                    let className = 'vs-adp-neutral';
+                    if (diff > 50) className = 'vs-adp-gold';
+                    else if (diff > 10) className = 'vs-adp-green';
+                    else if (diff < -10) className = 'vs-adp-red';
                     return <span className={className}>{diff > 0 ? '+' : ''}{diff}</span>;
                 })() : <span className="stat-neutral">—</span>}
             </td>

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -147,8 +147,8 @@ const PlayerList = ({ editable }: any) => {
         return !!expandedNotes[playerId];
     }
 
-    // Total columns for note row colSpan: rank + player + adp + stats + actions
-    const totalColumns = 3 + columns.length + (editable ? 1 : 0);
+    // Total columns for note row colSpan: rank + player + adp + espn + fpro + vsadp + stats + actions
+    const totalColumns = 6 + columns.length + (editable ? 1 : 0);
 
     return (
         <>
@@ -179,6 +179,7 @@ const PlayerList = ({ editable }: any) => {
                             <th className="adp-header">ADP</th>
                             <th className="rank-source-header">ESPN</th>
                             <th className="rank-source-header">FPRO</th>
+                            <th className="vs-adp-header">vsADP</th>
                             {columns.map(col => (
                                 <th
                                     key={col.id}


### PR DESCRIPTION
## Summary
Added a new "vsADP" (versus Average Draft Position) column to the player list that displays the difference between a player's expert ranking and their average draft position, with color-coded indicators for significant deviations.

## Key Changes
- **New vsADP Column**: Added a new column header and cell styling for displaying the difference between expert rank and ADP
- **Rank Differential Logic**: Implemented calculation that shows the difference between rounded ADP and the player's rank, with conditional styling:
  - Gold (+700 font weight) for differences > 50 (significant value)
  - Green for differences between 10-50 (moderate value)
  - Red for differences < -10 (overvalued)
  - Neutral grey-brown for differences between -10 and 10
- **Visual Styling**: Added CSS classes for vsADP headers and cells with:
  - Fixed 44px width for consistent column sizing
  - Smaller font size (0.65rem for headers, 0.8rem for cells)
  - Center text alignment
  - Left/right borders matching the ADP column styling
- **Layout Update**: Updated the total column count calculation to account for the new vsADP column (from 3 to 6 base columns)

## Implementation Details
- The vsADP value displays with a "+" prefix for positive differences
- Falls back to "—" when ADP data is unavailable
- Color thresholds are designed to highlight players with significant differences between expert consensus and draft market value

https://claude.ai/code/session_01R9YoaNePSxuRp1kU99RDQt