### PR TITLE
Improve dynamic column counting and add notes toggle label

### DIFF
--- a/client/src/components/FilterBar.tsx
+++ b/client/src/components/FilterBar.tsx
@@ -86,6 +86,7 @@ const FilterBar = (props) => {
                         title={allNotesExpanded ? 'Collapse all notes' : 'Expand all notes'}
                     >
                         <CommentIcon />
+                        <span>{allNotesExpanded ? 'Notes On' : 'Notes Off'}</span>
                     </button>
                     <button
                         className="gear-btn"

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -147,8 +147,8 @@ const PlayerList = ({ editable }: any) => {
         return !!expandedNotes[playerId];
     }
 
-    // Total columns for note row colSpan: rank + player + adp + stats + actions
-    const totalColumns = 3 + columns.length + (editable ? 1 : 0);
+    // Total columns for note row colSpan: rank + player + adp + ESPN + FPRO + stats + actions
+    const totalColumns = 5 + columns.length + (editable ? 1 : 0);
 
     return (
         <>

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useState, useEffect} from 'react'
+import React, {useContext, useState, useEffect, useRef} from 'react'
 import {
     DndContext,
     KeyboardSensor,
@@ -147,8 +147,8 @@ const PlayerList = ({ editable }: any) => {
         return !!expandedNotes[playerId];
     }
 
-    // Total columns for note row colSpan: rank + player + adp + ESPN + FPRO + stats + actions
-    const totalColumns = 5 + columns.length + (editable ? 1 : 0);
+    const headerRef = useRef<HTMLTableRowElement>(null);
+    const totalColumns = headerRef.current?.children.length || 1;
 
     return (
         <>
@@ -173,7 +173,7 @@ const PlayerList = ({ editable }: any) => {
             >
                 <table className="player-table">
                     <thead>
-                        <tr>
+                        <tr ref={headerRef}>
                             <th className="rank-header">#</th>
                             <th className="player-header">Player</th>
                             <th className="adp-header">ADP</th>


### PR DESCRIPTION
## Summary
This PR improves the PlayerList component's column counting logic and enhances the FilterBar's notes toggle button with a visual label.

## Key Changes
- **PlayerList**: Changed from hardcoded column calculation to dynamic counting using a ref to the header row
  - Added `useRef` import and created `headerRef` to reference the table header row
  - Replaced static `totalColumns` calculation with `headerRef.current?.children.length || 1`
  - This ensures the column count always matches the actual rendered header cells
  
- **FilterBar**: Added a text label to the notes toggle button
  - Added `<span>` element displaying "Notes On" or "Notes Off" based on `allNotesExpanded` state
  - Improves UX by providing clearer visual feedback of the current notes state alongside the icon

## Implementation Details
The dynamic column counting approach is more maintainable as it automatically adapts if header columns are added or removed, eliminating the need to manually update the calculation when the table structure changes.

https://claude.ai/code/session_01ARQC9ututfufLDB1qYWqbm