### PR TITLE
Simplify player table row highlighting styling

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -907,7 +907,7 @@ button[data-disabled] {
 .player-table {
   width: 100%;
   border-collapse: separate;
-  border-spacing: 0 2px;
+  border-spacing: 0;
 }
 
 .player-table thead th {
@@ -954,14 +954,8 @@ button[data-disabled] {
 .player-row td:first-child { border-radius: 6px 0 0 6px; }
 .player-row td:last-child  { border-radius: 0 6px 6px 0; }
 
-.player-row.highlighted td {
-  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
-}
 .player-row.highlighted td:first-child {
-  box-shadow: inset 1.5px 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
-}
-.player-row.highlighted td:last-child {
-  box-shadow: inset -1.5px 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
+  box-shadow: inset 3px 0 0 0 var(--highlight-blue);
 }
 .player-row.ignored td { opacity: 0.5; }
 


### PR DESCRIPTION
## Summary
Refactored the player table row highlighting styles to use a simpler, cleaner approach with a left border accent instead of complex inset box-shadows.

## Key Changes
- Removed vertical spacing between table rows by changing `border-spacing` from `0 2px` to `0`
- Simplified the highlighted row styling by removing the multi-directional inset box-shadow approach
- Replaced complex box-shadow logic with a single `inset 3px 0 0 0` left border accent on the first cell of highlighted rows
- Removed separate styling rules for highlighted rows and consolidated into a single rule for `highlighted td:first-child`

## Implementation Details
The new approach uses a left-side inset box-shadow (3px width) to create a visual accent for highlighted player rows, which is more maintainable and provides a cleaner visual design compared to the previous implementation that used top and bottom inset shadows across all cells.

https://claude.ai/code/session_01LgEz68u614q5CvqzwLD1Bd