### PR TITLE
Refactor player list styling and note input UI

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -944,6 +944,13 @@ button[data-disabled] {
   padding: 0.2rem 0.4rem;
   background: var(--soft-tan);
   vertical-align: middle;
+  border-bottom: 2px solid transparent;
+}
+
+/* Remove bottom gap when note row follows */
+.player-row:has(+ .note-row) td,
+.draggable-item:has(+ .note-row) td {
+  border-bottom: none;
 }
 
 /* Zebra striping — class-based to handle note rows */
@@ -955,7 +962,7 @@ button[data-disabled] {
 .player-row td:last-child  { border-radius: 0 6px 6px 0; }
 
 .player-row.highlighted td:first-child {
-  box-shadow: inset 3px 0 0 0 var(--highlight-blue);
+  box-shadow: inset 5px 0 0 0 var(--highlight-blue);
 }
 .player-row.ignored td { opacity: 0.5; }
 
@@ -1001,14 +1008,15 @@ button[data-disabled] {
 .player-note-input {
   width: 100%;
   resize: none;
-  border: 1px solid transparent;
+  border: 1px solid var(--tan-dark);
   border-radius: 4px;
-  background: transparent;
+  background: rgba(255, 255, 255, 0.7);
   font-family: inherit;
-  font-size: 0.7rem;
-  color: var(--greybrown);
-  padding: 0.1rem 0.3rem;
-  line-height: 1.3;
+  font-size: 0.75rem;
+  color: var(--brown);
+  padding: 0.3rem 0.5rem;
+  line-height: 1.4;
+  min-height: 32px;
   transition: border-color 0.15s ease, background 0.15s ease;
   overflow: hidden;
   margin-top: 0.1rem;
@@ -1019,8 +1027,8 @@ button[data-disabled] {
   }
 
   &:hover {
-    border-color: var(--tan-dark);
-    background: rgba(255, 255, 255, 0.5);
+    border-color: var(--greybrown);
+    background: rgba(255, 255, 255, 0.85);
   }
 
   &:focus {
@@ -1043,8 +1051,9 @@ button[data-disabled] {
 /* Note accordion row — seamless with parent */
 .note-row .note-row-cell {
   background: var(--soft-tan);
-  padding: 0 0.5rem 0.3rem 3.5rem !important;
+  padding: 0.2rem 0.5rem 0.4rem 3.5rem !important;
   border-radius: 0 0 6px 6px;
+  border-bottom: 2px solid transparent;
 }
 
 .note-row.even-row .note-row-cell {
@@ -1094,15 +1103,15 @@ button[data-disabled] {
   color: var(--brown);
 }
 
-/* Column group borders */
-.adp-header,
-.adp-cell {
-  border-left: 2px solid var(--tan-dark);
-}
-
-.vs-adp-header,
-.vs-adp-cell {
-  border-right: 2px solid var(--tan-dark);
+/* Column group spacers */
+.spacer-header,
+.spacer-cell {
+  width: 4px !important;
+  min-width: 4px;
+  max-width: 4px;
+  padding: 0 !important;
+  background: transparent !important;
+  border: none !important;
 }
 
 /* ADP cell */
@@ -1192,29 +1201,7 @@ button[data-disabled] {
 /* Border-radius on the cell before actions (the visual row end) */
 .player-row td:has(+ .actions-cell) { border-radius: 0 6px 6px 0; }
 
-/* Highlighted border on the cell before actions — close the right edge when actions hidden */
-.player-row.highlighted td:has(+ .actions-cell) {
-  box-shadow: inset -1.5px 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
-}
-.player-row.highlighted td.actions-cell {
-  box-shadow: none;
-}
-
-/* When hovered, extend the highlight border over the actions wrapper */
-.player-row.highlighted:hover td:has(+ .actions-cell) {
-  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
-}
-.player-row.highlighted .actions-wrapper {
-  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset -1.5px 0 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
-  border-radius: 0 6px 6px 0;
-}
-.draggable-item.highlighted:hover td:has(+ .actions-cell) {
-  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
-}
-.draggable-item.highlighted .actions-wrapper {
-  box-shadow: inset 0 1.5px 0 0 var(--highlight-blue), inset -1.5px 0 0 0 var(--highlight-blue), inset 0 -1.5px 0 0 var(--highlight-blue);
-  border-radius: 0 6px 6px 0;
-}
+/* No highlight border on actions overlay — the left tab is sufficient */
 
 .actions-header {
   width: 0;

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -907,7 +907,7 @@ button[data-disabled] {
 .player-table {
   width: 100%;
   border-collapse: separate;
-  border-spacing: 0 2px;
+  border-spacing: 0;
 }
 
 .player-table thead th {
@@ -944,6 +944,7 @@ button[data-disabled] {
   padding: 0.2rem 0.4rem;
   background: var(--soft-tan);
   vertical-align: middle;
+  border-top: 2px solid transparent;
 }
 
 /* Zebra striping — class-based to handle note rows */
@@ -1056,12 +1057,20 @@ button[data-disabled] {
 .note-row .note-row-cell {
   background: var(--soft-tan);
   padding: 0.2rem 0.5rem 0.4rem 3.5rem !important;
-  border-radius: 6px;
+  border-radius: 0 0 6px 6px;
 }
 
 .note-row.even-row .note-row-cell {
   background: #e0d3b0;
 }
+
+/* Remove bottom border-radius from player row when note row follows */
+.player-row:has(+ .note-row) td:first-child,
+.draggable-item:has(+ .note-row) td:first-child { border-radius: 6px 0 0 0; }
+.player-row:has(+ .note-row) td:last-child,
+.draggable-item:has(+ .note-row) td:last-child { border-radius: 0 6px 0 0; }
+.player-row:has(+ .note-row) td:has(+ .actions-cell),
+.draggable-item:has(+ .note-row) td:has(+ .actions-cell) { border-radius: 0; }
 
 .note-row .player-note-input {
   width: 100%;

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -907,7 +907,7 @@ button[data-disabled] {
 .player-table {
   width: 100%;
   border-collapse: separate;
-  border-spacing: 0;
+  border-spacing: 0 2px;
 }
 
 .player-table thead th {
@@ -944,13 +944,6 @@ button[data-disabled] {
   padding: 0.2rem 0.4rem;
   background: var(--soft-tan);
   vertical-align: middle;
-  border-bottom: 2px solid transparent;
-}
-
-/* Remove bottom gap when note row follows */
-.player-row:has(+ .note-row) td,
-.draggable-item:has(+ .note-row) td {
-  border-bottom: none;
 }
 
 /* Zebra striping — class-based to handle note rows */
@@ -962,7 +955,18 @@ button[data-disabled] {
 .player-row td:last-child  { border-radius: 0 6px 6px 0; }
 
 .player-row.highlighted td:first-child {
-  box-shadow: inset 5px 0 0 0 var(--highlight-blue);
+  position: relative;
+}
+
+.player-row.highlighted td:first-child::before {
+  content: '';
+  position: absolute;
+  left: -5px;
+  top: 0;
+  bottom: 0;
+  width: 5px;
+  background: var(--highlight-blue);
+  border-radius: 3px 0 0 3px;
 }
 .player-row.ignored td { opacity: 0.5; }
 
@@ -1052,21 +1056,12 @@ button[data-disabled] {
 .note-row .note-row-cell {
   background: var(--soft-tan);
   padding: 0.2rem 0.5rem 0.4rem 3.5rem !important;
-  border-radius: 0 0 6px 6px;
-  border-bottom: 2px solid transparent;
+  border-radius: 6px;
 }
 
 .note-row.even-row .note-row-cell {
   background: #e0d3b0;
 }
-
-/* Remove bottom border-radius from player row when note row follows */
-.player-row:has(+ .note-row) td:first-child,
-.draggable-item:has(+ .note-row) td:first-child { border-radius: 6px 0 0 0; }
-.player-row:has(+ .note-row) td:last-child,
-.draggable-item:has(+ .note-row) td:last-child { border-radius: 0 6px 0 0; }
-.player-row:has(+ .note-row) td:has(+ .actions-cell),
-.draggable-item:has(+ .note-row) td:has(+ .actions-cell) { border-radius: 0; }
 
 .note-row .player-note-input {
   width: 100%;
@@ -1106,9 +1101,9 @@ button[data-disabled] {
 /* Column group spacers */
 .spacer-header,
 .spacer-cell {
-  width: 4px !important;
-  min-width: 4px;
-  max-width: 4px;
+  width: 10px !important;
+  min-width: 10px;
+  max-width: 10px;
   padding: 0 !important;
   background: transparent !important;
   border: none !important;

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -199,8 +199,8 @@ const PlayerItem = (props) => {
 }
 
 const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable, isEven }) => {
-    const {updatePlayerNote, userRanking} = useContext(StoreContext);
-    const notesEditable = editable && (!userRanking?.isShared || !!userRanking?.pin);
+    const {updatePlayerNote} = useContext(StoreContext);
+    const notesEditable = editable;
     const [noteText, setNoteText] = useState(playerRanking?.note || '');
     const noteRef = useRef<HTMLTextAreaElement>(null);
 

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -120,6 +120,7 @@ const PlayerItem = (props) => {
                     </div>
                 </div>
             </td>
+            <td className="spacer-cell"></td>
             <td className="adp-cell">
                 <div className="adp-info">
                     {player.averageDraftPosition && (
@@ -151,6 +152,7 @@ const PlayerItem = (props) => {
                     return <span className={className}>{diff > 0 ? '+' : ''}{diff}</span>;
                 })() : <span className="stat-neutral">—</span>}
             </td>
+            <td className="spacer-cell"></td>
             {columns.map(column => (
                 <td key={column.id} className="stat-cell">
                     {renderCellValue(player, column.id)}

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -176,10 +176,12 @@ const PlayerList = ({ editable }: any) => {
                         <tr ref={headerRef}>
                             <th className="rank-header">#</th>
                             <th className="player-header">Player</th>
+                            <th className="spacer-header"></th>
                             <th className="adp-header">ADP</th>
                             <th className="rank-source-header">ESPN</th>
                             <th className="rank-source-header">FPRO</th>
                             <th className="vs-adp-header">vsADP</th>
+                            <th className="spacer-header"></th>
                             {columns.map(col => (
                                 <th
                                     key={col.id}


### PR DESCRIPTION
## Summary
This PR improves the visual design and usability of the player list by refactoring the highlight indicator styling, enhancing the note input field appearance, and replacing column borders with spacer columns for better visual separation.

## Key Changes

- **Highlight indicator redesign**: Replaced inset box-shadow approach with a left-side tab using a `::before` pseudo-element on the first cell of highlighted rows, providing a cleaner and more prominent visual indicator
- **Note input field improvements**: 
  - Changed from transparent to semi-opaque white background (`rgba(255, 255, 255, 0.7)`)
  - Added visible border using `var(--tan-dark)` instead of transparent
  - Increased padding and font size for better readability
  - Added minimum height of 32px for consistent sizing
  - Updated hover and focus states with improved contrast
- **Column separation refactor**: Replaced left/right borders on ADP and vsADP column groups with dedicated spacer columns (10px wide) for cleaner markup and more flexible styling
- **Note row padding adjustment**: Updated padding values for better vertical alignment in the note accordion row
- **Simplified note editing logic**: Removed `userRanking` context dependency from note editability check, now based solely on the `editable` prop

## Implementation Details

- The highlight indicator now uses absolute positioning relative to the first cell, allowing it to extend beyond the cell boundaries
- Spacer columns are implemented as empty table cells with transparent background and no padding/borders
- The note input field styling now provides better visual feedback with the semi-opaque background and visible border
- Removed complex box-shadow rules for highlighted rows with actions, simplifying the CSS significantly

https://claude.ai/code/session_01Tpcf5qSFDZoR2Kk4r8irt8