### PR TITLE
Flip stat cells to in-place editable inputs when pencil is clicked

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1063,58 +1063,54 @@ button[data-disabled] {
   width: 100%;
 }
 
-/* Projection edit row */
-.projection-edit-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  margin-bottom: 8px;
+/* In-place editable stat cells */
+.stat-cell.stat-cell-editing {
+  vertical-align: middle;
+  padding: 2px;
 }
 
-.projection-edit-field {
+.stat-cell-input-wrapper {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 4px;
-  background: rgba(255,255,255,0.5);
-  border-radius: 4px;
-  padding: 2px 6px;
-  border: 1px solid transparent;
+  gap: 1px;
 }
 
-.projection-edit-field.custom {
-  border-color: var(--navy, #2563eb);
-  background: rgba(37, 99, 235, 0.08);
-}
-
-.projection-edit-label {
-  font-size: 0.65rem;
-  font-weight: 600;
-  color: var(--greybrown, #888);
-  text-transform: uppercase;
-  letter-spacing: 0.02em;
-  min-width: 28px;
-}
-
-.projection-edit-input {
-  width: 48px;
-  padding: 2px 4px;
-  border: 1px solid #ccc;
+.stat-cell-input {
+  width: 44px;
+  padding: 2px 3px;
+  border: 1px solid #bbb;
   border-radius: 3px;
-  font-size: 0.75rem;
-  text-align: right;
+  font-size: 0.8rem;
+  text-align: center;
   background: white;
   font-family: inherit;
 }
 
-.projection-edit-input:focus {
+.stat-cell-input::placeholder {
+  color: #999;
+  font-style: normal;
+}
+
+.stat-cell-input:focus {
   outline: none;
   border-color: var(--navy, #2563eb);
   box-shadow: 0 0 0 1px var(--navy, #2563eb);
 }
 
-.projection-edit-field.custom .projection-edit-input {
+.stat-cell-input.custom {
   font-weight: 600;
   color: var(--navy, #2563eb);
+  border-color: var(--navy, #2563eb);
+}
+
+.stat-cell-input-label {
+  font-size: 0.55rem;
+  font-weight: 600;
+  color: var(--greybrown, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  line-height: 1;
 }
 
 /* Custom projection indicator in stat cells */

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -155,8 +155,18 @@ const PlayerItem = (props) => {
                 })() : <span className="stat-neutral">—</span>}
             </td>
             {columns.map(column => (
-                <td key={column.id} className="stat-cell">
-                    {renderCellValue(player, column.id)}
+                <td key={column.id} className={`stat-cell${showNote && editable && !isDraftMode ? ' stat-cell-editing' : ''}`}>
+                    {showNote && editable && !isDraftMode ? (
+                        <StatCellInput
+                            playerId={playerId}
+                            statId={column.id}
+                            label={column.name}
+                            projections={projections}
+                            customProjections={playerRanking?.customProjections}
+                        />
+                    ) : (
+                        renderCellValue(player, column.id)
+                    )}
                 </td>
             ))}
             {editable && !isDraftMode && (
@@ -199,54 +209,21 @@ const PlayerItem = (props) => {
     )
 }
 
-const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable, isEven, columns }) => {
-    const {players, updatePlayerNote, updatePlayerProjection, userRanking} = useContext(StoreContext);
+const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable, isEven }) => {
+    const {updatePlayerNote, userRanking} = useContext(StoreContext);
     const notesEditable = editable && (!userRanking?.isShared || !!userRanking?.pin);
     const [noteText, setNoteText] = useState(playerRanking?.note || '');
     const noteRef = useRef<HTMLTextAreaElement>(null);
 
-    const player = players[playerId];
-    const projections = player?.projections || {};
-    const customProjections = playerRanking?.customProjections || {};
-
     useEffect(() => {
-        if (notesEditable && !columns?.length) {
+        if (notesEditable) {
             setTimeout(() => noteRef.current?.focus(), 0);
         }
     }, []);
 
-    const handleProjectionBlur = (statId, inputValue) => {
-        const original = projections[statId];
-        const parsed = inputValue === '' ? null : Number(inputValue);
-        // Remove override if empty or matches original
-        if (parsed === null || parsed === original) {
-            updatePlayerProjection(playerId, statId, null);
-        } else if (!isNaN(parsed)) {
-            updatePlayerProjection(playerId, statId, parsed);
-        }
-    };
-
     return (
         <tr className={`note-row${isEven ? ' even-row' : ''}`}>
             <td colSpan={colSpan} className="note-row-cell">
-                {notesEditable && columns?.length > 0 && (
-                    <div className="projection-edit-row">
-                        {columns.map(col => {
-                            const isCustom = customProjections[col.id] != null;
-                            const currentValue = customProjections[col.id] ?? projections[col.id] ?? '';
-                            return (
-                                <ProjectionInput
-                                    key={col.id}
-                                    statId={col.id}
-                                    label={col.name}
-                                    defaultValue={currentValue}
-                                    isCustom={isCustom}
-                                    onBlur={handleProjectionBlur}
-                                />
-                            );
-                        })}
-                    </div>
-                )}
                 {notesEditable ? (
                     <textarea
                         ref={noteRef}
@@ -265,20 +242,36 @@ const PlayerNoteRow = ({ playerId, playerRanking, colSpan, editable, isEven, col
     )
 }
 
-const ProjectionInput = ({ statId, label, defaultValue, isCustom, onBlur }) => {
-    const [value, setValue] = useState(defaultValue !== '' ? String(defaultValue) : '');
+const StatCellInput = ({ playerId, statId, label, projections, customProjections }) => {
+    const {updatePlayerProjection} = useContext(StoreContext);
+    const isCustom = customProjections?.[statId] != null;
+    const originalValue = projections?.[statId] ?? '';
+    const currentValue = customProjections?.[statId] ?? originalValue;
+    const [value, setValue] = useState(isCustom ? String(currentValue) : '');
+
+    const handleBlur = () => {
+        const parsed = value === '' ? null : Number(value);
+        if (parsed === null || parsed === originalValue) {
+            updatePlayerProjection(playerId, statId, null);
+        } else if (!isNaN(parsed)) {
+            updatePlayerProjection(playerId, statId, parsed);
+        }
+    };
+
+    const placeholder = originalValue !== '' ? formatStatValue(statId, originalValue) : '—';
 
     return (
-        <div className={`projection-edit-field${isCustom ? ' custom' : ''}`}>
-            <label className="projection-edit-label">{label}</label>
+        <div className="stat-cell-input-wrapper">
             <input
                 type="text"
                 inputMode="decimal"
-                className="projection-edit-input"
+                className={`stat-cell-input${isCustom ? ' custom' : ''}`}
                 value={value}
+                placeholder={placeholder}
                 onChange={(e) => setValue(e.target.value)}
-                onBlur={() => onBlur(statId, value)}
+                onBlur={handleBlur}
             />
+            <span className="stat-cell-input-label">{label}</span>
         </div>
     );
 }

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -248,7 +248,6 @@ const PlayerList = ({ editable }: any) => {
                                                 colSpan={totalColumns}
                                                 editable={editable}
                                                 isEven={isEven}
-                                                columns={columns}
                                             />
                                         )}
                                     </React.Fragment>
@@ -272,7 +271,6 @@ const PlayerList = ({ editable }: any) => {
                                                 colSpan={totalColumns}
                                                 editable={editable}
                                                 isEven={isEven}
-                                                columns={columns}
                                             />
                                         )}
                                     </React.Fragment>


### PR DESCRIPTION
- Stat cells become inline inputs with label underneath when editing
- Only visible table columns are editable (no separate projection row)
- Placeholder shows original projection value (clearing resets to default)
- Custom overrides highlighted with blue border and bold text
- PlayerNoteRow simplified to notes-only textarea

https://claude.ai/code/session_01SGBFhQVYNgAVq4HT1sfUMc