### PR TITLE
Use FantasyPros ADP data when available for player rankings

### DIFF
--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -54,7 +54,7 @@ function build_player_store(
             projections: format_projections(projections[player.id]),
             headshot: `https://a.espncdn.com/combiner/i?img=/i/headshots/mlb/players/full/${player.id}.png?w=96&h=70&cb=1`,
             ownership: player.ownership || 0,
-            averageDraftPosition: player.average_draft_position || null,
+            averageDraftPosition: fp_data?.adp ?? player.average_draft_position ?? null,
             percentChange: player.percent_change || null,
             injuryStatus: player.injury_status || null,
             age: player.age || null,


### PR DESCRIPTION
## Summary
Updated the player store builder to prioritize FantasyPros ADP (Average Draft Position) data over the existing player average draft position field when available.

## Key Changes
- Modified `averageDraftPosition` field assignment in `build_player_store()` to use a fallback chain:
  - First, use `fp_data?.adp` (FantasyPros data) if available
  - Fall back to `player.average_draft_position` if FantasyPros data is not present
  - Finally, default to `null` if neither source has data

## Implementation Details
- Uses the nullish coalescing operator (`??`) to safely handle undefined/null values
- Maintains backward compatibility by preserving existing player data as a fallback
- Allows FantasyPros data to take precedence when available, improving data accuracy

https://claude.ai/code/session_013aNDYPQM7B2AZPtarFyU7G