### PR TITLE
Fix player image fallback to prevent infinite loops

### DIFF
--- a/client/src/components/PlayerList/PlayerCard.tsx
+++ b/client/src/components/PlayerList/PlayerCard.tsx
@@ -14,6 +14,8 @@ import {
     Tooltip
 } from 'recharts'
 
+const FALLBACK_IMAGE = `${import.meta.env.BASE_URL}assets/images/player-fallback.png`
+
 const EXLUDED_POSITIONS = ['P', 'UTIL']
 
 const PlayerCard = ({ playerId, onClose }) => {
@@ -45,7 +47,7 @@ const PlayerCard = ({ playerId, onClose }) => {
                 <div className="player-card-header">
                     <div className="player-photos large">
                         { teamLogo && (<img className="team-logo" src={teamLogo} width="48" />) }
-                        <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="180" onError={(e) => { (e.target as HTMLImageElement).src = '/assets/images/player-fallback.png'; }} />
+                        <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="180" onError={(e) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith(FALLBACK_IMAGE)) { img.src = FALLBACK_IMAGE; } }} />
                     </div>
                     <div className="player-info">
                         <h2>{player.name}</h2>

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -3,6 +3,8 @@ import {StoreContext} from '~/data/store'
 import {DraftContext} from '~/data/draftContext'
 import {formatStatValue, evaluateStatQuality} from '~/features/stats'
 
+const FALLBACK_IMAGE = `${import.meta.env.BASE_URL}assets/images/player-fallback.png`
+
 const EXCLUDED_POSITIONS = ['1B/3B', '2B/SS', 'P', 'UTIL']
 
 const INJURY_LABELS = {
@@ -101,7 +103,7 @@ const PlayerItem = (props) => {
             <td className="player-identity-cell">
                 <div className="player-photos">
                     {teamLogo && <img className="team-logo" src={teamLogo} width="24" />}
-                    <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="72" onError={(e) => { (e.target as HTMLImageElement).src = '/assets/images/player-fallback.png'; }} />
+                    <img className="player-headshot" src={player.headshot.replace('w=96', 'w=426').replace('h=70', 'h=320')} width="72" onError={(e) => { const img = e.target as HTMLImageElement; if (!img.src.endsWith(FALLBACK_IMAGE)) { img.src = FALLBACK_IMAGE; } }} />
                 </div>
                 <div className="player-identity">
                     <div className="player-name-row">


### PR DESCRIPTION
## Summary
Improved the player image fallback handling to prevent infinite error loops when loading player headshots fails.

## Key Changes
- Added `FALLBACK_IMAGE` constant in both `PlayerCard.tsx` and `PlayerItem.tsx` that uses `import.meta.env.BASE_URL` for proper asset path resolution
- Updated the `onError` handler for player headshot images to check if the current source is already the fallback image before attempting to set it again
- This prevents the error handler from being triggered repeatedly if the fallback image itself fails to load

## Implementation Details
- The fallback check uses `endsWith()` to verify the image source matches the fallback path before reassigning
- This approach ensures the error handler only executes once per image, avoiding potential infinite loops
- The constant definition at the module level makes the fallback path consistent and easier to maintain across components

https://claude.ai/code/session_01Jx4kik4Jk3wb43rLSqK41w