### PR TITLE
Refine UI styling for ignored players and stat cells

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -973,6 +973,7 @@ button[data-disabled] {
   border-radius: 3px 0 0 3px;
 }
 .player-row.ignored td { opacity: 0.5; }
+.player-row.ignored:hover .actions-cell { opacity: 1; }
 
 /* Draft mode compact rows */
 .draft-mode .player-row td { padding: 0.15rem 0.3rem; }
@@ -1084,7 +1085,7 @@ button[data-disabled] {
 /* In-place editable stat cells */
 .stat-cell.stat-cell-editing {
   vertical-align: middle;
-  padding: 2px;
+  padding: 1px;
 }
 
 .stat-cell-input-wrapper {
@@ -1095,8 +1096,8 @@ button[data-disabled] {
 }
 
 .stat-cell-input {
-  width: 44px;
-  padding: 2px 3px;
+  width: 40px;
+  padding: 1px 2px;
   border: 1px solid #bbb;
   border-radius: 3px;
   font-size: 0.8rem;
@@ -1182,12 +1183,7 @@ button[data-disabled] {
 }
 
 .spacer-header {
-  background: transparent !important;
   box-shadow: none !important;
-}
-
-.spacer-cell {
-  background: transparent !important;
 }
 
 /* ADP cell */


### PR DESCRIPTION
This PR improves the visual presentation and usability of the player draft interface through targeted CSS refinements.

**Summary**
Updated styling for ignored player rows and stat cell inputs to enhance visibility and reduce visual clutter while maintaining a cleaner, more compact layout.

**Key changes**
- Added hover effect to show action buttons on ignored player rows, improving discoverability while keeping them visually de-emphasized at rest
- Reduced padding on stat cell inputs (from 2px to 1px) and adjusted input width (from 44px to 40px) for a more compact editing experience
- Removed unnecessary `background: transparent !important` declarations from spacer header and cell styles, simplifying the CSS

**Implementation details**
- The new `.player-row.ignored:hover .actions-cell { opacity: 1; }` rule ensures action buttons become visible when users hover over ignored rows, making it easier to interact with them without removing the visual distinction
- Stat cell input adjustments create a tighter, more refined appearance while maintaining usability
- Cleanup of redundant background declarations reduces CSS specificity and improves maintainability

https://claude.ai/code/session_01WYmqF3N5R8YsfQ6DeNmi5g