### PR TITLE
Improve share modal UX with close button and better form labels

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -2518,6 +2518,65 @@ button {
   gap: 1rem;
 }
 
+/* Modal close X button - top right corner */
+.modal-close-x {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  font-size: 1.5rem;
+  line-height: 1;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--greybrown);
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.modal-close-x:hover {
+  color: var(--charcoal);
+  background-color: rgba(0, 0, 0, 0.05);
+}
+
+/* Share modal bottom dismiss button */
+.share-modal-close {
+  background-color: var(--greybrown);
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 0.6rem 1.5rem;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  align-self: center;
+}
+
+.share-modal-close:hover {
+  background-color: var(--charcoal);
+}
+
+/* Already-shared view */
+.share-existing {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.share-existing h3 {
+  color: var(--green-monster);
+  margin: 0;
+}
+
+.share-info-row {
+  font-size: 0.85rem;
+  color: var(--greybrown);
+}
+
+.share-info-row .label {
+  font-weight: 600;
+  color: var(--brown);
+}
+
 .stats-legend h3 {
   text-align: center;
   margin-bottom: 1rem;

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -259,12 +259,13 @@ const AppHeader = () => {
                     <div className="modal-content" onClick={(e) => e.stopPropagation()}>
                         {shareUrl ? (
                             <div className="share-success">
+                                <button className="modal-close-x" onClick={toggleShareModal} aria-label="Close">&times;</button>
                                 <h3>Ranking Shared!</h3>
                                 <div className="share-url">
-                                    <input 
-                                        type="text" 
-                                        readOnly 
-                                        value={shareUrl} 
+                                    <input
+                                        type="text"
+                                        readOnly
+                                        value={shareUrl}
                                         onClick={(e) => (e.target as HTMLInputElement).select()}
                                     />
                                     <button onClick={copyToClipboard}>
@@ -277,25 +278,38 @@ const AppHeader = () => {
                                         <p className="pin-note">Keep this PIN to edit later</p>
                                     </div>
                                 )}
-                                <button onClick={toggleShareModal} className="close-button small">
-                                    Close
+                                <button onClick={toggleShareModal} className="share-modal-close">
+                                    Done
                                 </button>
                             </div>
                         ) : isShared ? (
                             <div className="share-existing">
+                                <button className="modal-close-x" onClick={toggleShareModal} aria-label="Close">&times;</button>
                                 <h3>Share Ranking</h3>
-                                <p>Your ranking ID: <strong>{ranking.id}</strong></p>
+                                {ranking.author && (
+                                    <p className="share-info-row">
+                                        <span className="label">By:</span> {ranking.author}
+                                    </p>
+                                )}
+                                {ranking.description && (
+                                    <p className="share-info-row">
+                                        <span className="label">Description:</span> {ranking.description}
+                                    </p>
+                                )}
                                 <div className="share-url">
-                                    <input 
-                                        type="text" 
-                                        readOnly 
-                                        value={getShareUrl() || ''} 
+                                    <input
+                                        type="text"
+                                        readOnly
+                                        value={getShareUrl() || ''}
                                         onClick={(e) => (e.target as HTMLInputElement).select()}
                                     />
                                     <button onClick={() => {
-                                        navigator.clipboard.writeText(getShareUrl() || '');
-                                        setIsCopied(true);
-                                        setTimeout(() => setIsCopied(false), 2000);
+                                        const url = getShareUrl();
+                                        if (url) {
+                                            navigator.clipboard.writeText(url);
+                                            setIsCopied(true);
+                                            setTimeout(() => setIsCopied(false), 2000);
+                                        }
                                     }}>
                                         {isCopied ? 'Copied!' : 'Copy'}
                                     </button>
@@ -303,24 +317,25 @@ const AppHeader = () => {
                                 {!pin && (
                                     <div className="edit-pin">
                                         <label htmlFor="edit-pin">PIN to edit:</label>
-                                        <input 
+                                        <input
                                             id="edit-pin"
-                                            type="password" 
-                                            placeholder="Enter PIN" 
-                                            value={pin} 
+                                            type="password"
+                                            placeholder="Enter PIN"
+                                            value={pin}
                                             onChange={(e) => setPin(e.target.value)}
                                         />
                                     </div>
                                 )}
-                                <button onClick={toggleShareModal} className="close-button small">
-                                    Close
+                                <button onClick={toggleShareModal} className="share-modal-close">
+                                    Done
                                 </button>
                             </div>
                         ) : (
                             <form onSubmit={handleShare} className="share-form">
+                                <button type="button" className="modal-close-x" onClick={toggleShareModal} aria-label="Close">&times;</button>
                                 <h3>Share Your Ranking</h3>
                                 <div className="form-group">
-                                    <label htmlFor="author">Your Name (optional):</label>
+                                    <label htmlFor="author">Your Name</label>
                                     <input
                                         type="text"
                                         id="author"
@@ -330,7 +345,7 @@ const AppHeader = () => {
                                     />
                                 </div>
                                 <div className="form-group">
-                                    <label htmlFor="description">Description (optional):</label>
+                                    <label htmlFor="description">Description</label>
                                     <textarea
                                         id="description"
                                         value={description}
@@ -340,7 +355,7 @@ const AppHeader = () => {
                                     />
                                 </div>
                                 <div className="form-group">
-                                    <label htmlFor="pin">PIN (optional):</label>
+                                    <label htmlFor="pin">PIN</label>
                                     <input
                                         type="password"
                                         id="pin"
@@ -348,21 +363,21 @@ const AppHeader = () => {
                                         onChange={(e) => setNewPin(e.target.value)}
                                         placeholder="4-6 digits"
                                     />
-                                    <p className="field-hint">Create a PIN to edit later</p>
+                                    <p className="field-hint">Optional. Create a PIN to edit from another device.</p>
                                 </div>
                                 {error && <div className="error">{error}</div>}
                                 <div className="form-actions">
-                                    <button 
-                                        type="submit" 
+                                    <button
+                                        type="submit"
                                         className="submit-button"
                                         disabled={isSubmitting}
                                     >
                                         {isSubmitting ? 'Sharing...' : 'Share'}
                                     </button>
-                                    <button 
-                                        type="button" 
-                                        onClick={toggleShareModal} 
-                                        className="cancel-button small"
+                                    <button
+                                        type="button"
+                                        onClick={toggleShareModal}
+                                        className="cancel-button"
                                     >
                                         Cancel
                                     </button>

--- a/client/src/components/ShareRanking.tsx
+++ b/client/src/components/ShareRanking.tsx
@@ -73,40 +73,45 @@ const ShareRanking = () => {
     };
 
     // For already shared rankings, just show the URL
-    if (isShared && ranking.id !== 'local') {
+    if (isShared && !ranking.id.startsWith('local')) {
         const url = getShareUrl();
         return (
             <div className="share-ranking">
                 <h3>Share Your Ranking</h3>
-                <p>Your ranking is already shared with ID: <strong>{ranking.id}</strong></p>
+                {ranking.author && (
+                    <p className="share-info-row">
+                        <span className="label">By:</span> {ranking.author}
+                    </p>
+                )}
+                {ranking.description && (
+                    <p className="share-info-row">
+                        <span className="label">Description:</span> {ranking.description}
+                    </p>
+                )}
                 <div className="share-url">
-                    <input 
-                        type="text" 
-                        readOnly 
-                        value={url} 
+                    <input
+                        type="text"
+                        readOnly
+                        value={url}
                         onClick={(e) => (e.target as HTMLInputElement).select()}
                     />
                     <button onClick={() => {
-                        navigator.clipboard.writeText(url);
-                        setIsCopied(true);
-                        setTimeout(() => setIsCopied(false), 2000);
+                        if (url) {
+                            navigator.clipboard.writeText(url);
+                            setIsCopied(true);
+                            setTimeout(() => setIsCopied(false), 2000);
+                        }
                     }}>
                         {isCopied ? 'Copied!' : 'Copy URL'}
                     </button>
                 </div>
-                {ranking.author && (
-                    <p>Created by: {ranking.author}</p>
-                )}
-                {ranking.description && (
-                    <p className="ranking-description">{ranking.description}</p>
-                )}
                 {!pin && (
                     <div className="edit-pin">
                         <p>Enter PIN to edit this ranking:</p>
-                        <input 
-                            type="password" 
-                            placeholder="PIN" 
-                            value={pin} 
+                        <input
+                            type="password"
+                            placeholder="PIN"
+                            value={pin}
                             onChange={(e) => setPin(e.target.value)}
                         />
                     </div>
@@ -146,15 +151,15 @@ const ShareRanking = () => {
                                     <p className="pin-note">Keep this PIN to edit your ranking later!</p>
                                 </div>
                             )}
-                            <button onClick={toggleForm} className="close-button">
-                                Close
+                            <button onClick={toggleForm} className="share-modal-close">
+                                Done
                             </button>
                         </div>
                     ) : (
                         // Show the share form
                         <form onSubmit={handleShare} className="share-form">
                             <div className="form-group">
-                                <label htmlFor="author">Your Name (optional):</label>
+                                <label htmlFor="author">Your Name</label>
                                 <input
                                     type="text"
                                     id="author"
@@ -164,7 +169,7 @@ const ShareRanking = () => {
                                 />
                             </div>
                             <div className="form-group">
-                                <label htmlFor="description">Description (optional):</label>
+                                <label htmlFor="description">Description</label>
                                 <textarea
                                     id="description"
                                     value={description}
@@ -174,7 +179,7 @@ const ShareRanking = () => {
                                 />
                             </div>
                             <div className="form-group">
-                                <label htmlFor="pin">PIN for Editing (optional):</label>
+                                <label htmlFor="pin">PIN</label>
                                 <input
                                     type="password"
                                     id="pin"
@@ -183,7 +188,7 @@ const ShareRanking = () => {
                                     placeholder="4-6 digits"
                                 />
                                 <p className="field-hint">
-                                    Create a PIN if you want to edit this ranking later from another device.
+                                    Optional. Create a PIN to edit from another device.
                                 </p>
                             </div>
                             {error && <div className="error">{error}</div>}

--- a/client/src/data/useUserRanking.tsx
+++ b/client/src/data/useUserRanking.tsx
@@ -48,7 +48,7 @@ const useUserRanking = (players) => {
             id: rankingToSave.id,
             author: rankingToSave.author,
             description: rankingToSave.description,
-            isShared: rankingToSave.id !== 'local',
+            isShared: !rankingToSave.id.startsWith('local'),
             createdAt: rankingToSave.createdAt,
             updatedAt: rankingToSave.updatedAt,
             name: rankingToSave.name || (rankingToSave.author 
@@ -164,7 +164,7 @@ const useUserRanking = (players) => {
                         // Use the stored version
                         const parsedRanking = JSON.parse(storedRanking);
                         setRanking(parsedRanking);
-                        setIsShared(rankingId !== 'local');
+                        setIsShared(!rankingId.startsWith('local'));
                         return; // Exit early after loading the URL ranking
                     } else {
                         // Fetch from server
@@ -186,7 +186,7 @@ const useUserRanking = (players) => {
                     
                     if (storedRanking) {
                         setRanking(JSON.parse(storedRanking));
-                        setIsShared(mostRecentId !== 'local');
+                        setIsShared(!mostRecentId.startsWith('local'));
                     } else {
                         // Create new if we can't find the stored data
                         createNewRanking(players);


### PR DESCRIPTION
## Summary
Enhanced the share ranking modal interface with improved user experience, including a dedicated close button in the top-right corner, clearer form labels, and better display of ranking metadata.

## Key Changes

- **Added modal close button**: Implemented a consistent `×` close button in the top-right corner of all share modal states (success, existing share, and form) for easier dismissal
- **Updated form labels**: Removed "(optional)" from form field labels (Author, Description, PIN) and moved the optional context to helper text for cleaner presentation
- **Improved PIN helper text**: Updated hint text to be more concise: "Optional. Create a PIN to edit from another device."
- **Enhanced shared ranking display**: When viewing an already-shared ranking, now displays author and description in a structured format with labeled rows instead of inline text
- **Refactored close buttons**: Changed bottom dismiss buttons from "Close" to "Done" with updated styling (`.share-modal-close` class) for better visual hierarchy
- **Fixed share URL validation**: Updated logic to check if ranking ID starts with 'local' rather than exact equality, improving handling of local ranking variants
- **Code formatting**: Standardized JSX attribute formatting across input elements and buttons for consistency

## Implementation Details

- The modal close button uses `aria-label="Close"` for accessibility
- Share info rows use a `.share-info-row` class with labeled spans for consistent styling
- Added null checks when copying share URLs to prevent errors
- Updated `useUserRanking.tsx` to use `.startsWith('local')` for more robust local ranking detection

https://claude.ai/code/session_01DKGJHdMtnsCcK9G65KZAQF