### PR TITLE
Fix stat category display for position-specific players

### DIFF
--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -2,6 +2,11 @@ import {useContext, useState, useRef, useEffect} from 'react'
 import {StoreContext} from '~/data/store'
 import {DraftContext} from '~/data/draftContext'
 import {formatStatValue, evaluateStatQuality} from '~/features/stats'
+import {isBatter, isPitcher} from '~/features/positions'
+import {ALL_BATTING_COLUMNS, ALL_PITCHING_COLUMNS} from '~/features/filtering/columns'
+
+const BATTING_COLUMN_IDS = new Set(ALL_BATTING_COLUMNS.map(col => col.id));
+const PITCHING_COLUMN_IDS = new Set(ALL_PITCHING_COLUMNS.map(col => col.id));
 
 const FALLBACK_IMAGE = `${import.meta.env.BASE_URL}assets/images/player-fallback.png`
 
@@ -103,6 +108,16 @@ const PlayerItem = (props) => {
     const customProjections = useCustom ? playerRanking?.customProjections : null;
 
     const renderCellValue = (player, columnId) => {
+        // Show "--" for inapplicable stat categories (e.g., pitching stats for batters)
+        const playerHasBattingPos = player.pos?.some(p => isBatter(p));
+        const playerHasPitchingPos = player.pos?.some(p => isPitcher(p));
+        if (PITCHING_COLUMN_IDS.has(columnId) && !playerHasPitchingPos) {
+            return <span className="stat-neutral">—</span>;
+        }
+        if (BATTING_COLUMN_IDS.has(columnId) && !playerHasBattingPos) {
+            return <span className="stat-neutral">—</span>;
+        }
+
         const isCustom = customProjections?.[columnId] != null;
         let value = customProjections?.[columnId] ?? projections?.[columnId] ?? player[columnId] ?? null;
 

--- a/server/services/fangraphs.ts
+++ b/server/services/fangraphs.ts
@@ -77,6 +77,11 @@ export function build_player_projections(
             }
         }
 
+        // Prevent batting SO from leaking into K (pitcher strikeouts) via format_projections
+        if (player.eligible_slots?.includes(SLOT_IDS.UTIL) && !player.eligible_slots?.includes(SLOT_IDS.PITCHER)) {
+            delete projection.SO;
+        }
+
         player_projections[player.id] = projection;
     }
 
@@ -168,6 +173,11 @@ export async function fetch_historical_stats(
                         HR: merged?.HR || 0,
                         HRA: pitching.HR,
                     };
+                }
+
+                // Prevent batting SO from leaking into K for batter-only players
+                if (!pitching && !player.eligible_slots?.includes(SLOT_IDS.PITCHER)) {
+                    delete merged.SO;
                 }
 
                 if (!historical_stats[player.id]) {

--- a/server/utils/formatters.ts
+++ b/server/utils/formatters.ts
@@ -114,7 +114,7 @@ export function format_projections(
         SB: projection['SB'] || 0,
         OBP: projection['OBP'] || 0,
         AVG: projection['AVG'] || 0,
-        KO: projection['SO'] || 0,
+        KO: projection['KO'] || projection['SO'] || 0,
         CS: projection['CS'] || 0,
         OPS: projection['OPS'] || 0,
         SLG: projection['SLG'] || 0,


### PR DESCRIPTION
## Summary
This PR fixes issues with displaying and handling statistics for players based on their eligible positions. It prevents pitching stats from appearing for batter-only players and batting stats from appearing for pitcher-only players, while also correcting a data mapping issue in the projection formatter.

## Key Changes

- **Client-side filtering**: Added position-aware stat filtering in `PlayerItem.tsx` to display "—" for inapplicable stat categories based on player position (e.g., hide pitching stats for batters)
  - Imports position helper functions (`isBatter`, `isPitcher`) and column definitions
  - Checks player positions before rendering each stat cell
  
- **Server-side data cleanup**: Modified `fangraphs.ts` to prevent batting strikeout data (SO) from contaminating pitcher strikeout data (K)
  - Removes SO from projections for utility-eligible players who aren't pitchers
  - Removes SO from historical stats for batter-only players
  
- **Projection formatter fix**: Corrected `format_projections` in `formatters.ts` to properly map strikeout data
  - Changed `KO` field to check for `KO` first, then fall back to `SO`, instead of only checking `SO`
  - Prevents loss of strikeout data when both fields might be present

## Implementation Details
The changes work together to ensure data integrity: server-side cleanup removes ambiguous SO values for non-pitchers, while the formatter handles the mapping correctly, and the client respects position eligibility when displaying stats.

https://claude.ai/code/session_018ucMbW185mXPPduysxstjA