### PR TITLE
Add positional ranking support for FantasyPros data

### DIFF
--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -11,6 +11,7 @@ const PITCHING_COLUMN_IDS = new Set(ALL_PITCHING_COLUMNS.map(col => col.id));
 const FALLBACK_IMAGE = `${import.meta.env.BASE_URL}assets/images/player-fallback.png`
 
 const EXCLUDED_POSITIONS = ['1B/3B', '2B/SS', 'P', 'UTIL']
+const SIMPLE_POSITION_FILTERS = new Set(['C', '1B', '2B', 'SS', '3B', 'OF', 'DH', 'SP', 'RP']);
 
 const INJURY_LABELS = {
     'DAY_TO_DAY': 'DTD',
@@ -90,7 +91,7 @@ const RowActions = ({ playerId, playerRanking, showNote, isEditing, onToggleNote
 }
 
 const PlayerItem = (props) => {
-    const {playerId, playerRanking, editable, onNameClick, columns, rank, showNote, isEditing, onToggleNote} = props
+    const {playerId, playerRanking, editable, onNameClick, columns, rank, posFilter, showNote, isEditing, onToggleNote} = props
     const {players, teams, mode, ranking} = useContext(StoreContext);
     const {isMyTurn, draftPlayer} = useContext(DraftContext);
 
@@ -195,7 +196,19 @@ const PlayerItem = (props) => {
                 {player.fantasyProsRank ? player.fantasyProsRank : <span className="stat-neutral">—</span>}
             </td>
             <td className="vs-adp-cell">
-                {player.averageDraftPosition ? (() => {
+                {(() => {
+                    const isPositionalMode = posFilter && SIMPLE_POSITION_FILTERS.has(posFilter);
+                    if (isPositionalMode) {
+                        const fproRank = player.fantasyProsPositionalRank?.[posFilter];
+                        if (!fproRank) return <span className="stat-neutral">—</span>;
+                        const diff = fproRank - rank;
+                        let className = 'vs-adp-neutral';
+                        if (diff > 50) className = 'vs-adp-gold';
+                        else if (diff > 10) className = 'vs-adp-green';
+                        else if (diff < -10) className = 'vs-adp-red';
+                        return <span className={className}>{diff > 0 ? '+' : ''}{diff}</span>;
+                    }
+                    if (!player.averageDraftPosition) return <span className="stat-neutral">—</span>;
                     const adpRound = Math.round(player.averageDraftPosition);
                     const diff = adpRound - rank;
                     let className = 'vs-adp-neutral';
@@ -203,7 +216,7 @@ const PlayerItem = (props) => {
                     else if (diff > 10) className = 'vs-adp-green';
                     else if (diff < -10) className = 'vs-adp-red';
                     return <span className={className}>{diff > 0 ? '+' : ''}{diff}</span>;
-                })() : <span className="stat-neutral">—</span>}
+                })()}
             </td>
             <td className="spacer-cell"></td>
             {columns.map(column => (

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -24,6 +24,8 @@ import {DraftContext} from '~/data/draftContext'
 import {StatsPrefsContext} from '~/data/statsPrefsContext'
 import {statsForFilter} from '~/features/filtering/columns'
 
+const SIMPLE_POSITION_FILTERS = new Set(['C', '1B', '2B', 'SS', '3B', 'OF', 'DH', 'SP', 'RP']);
+
 const PlayerList = ({ editable }: any) => {
     const {players, ranking, mode, toggleCustomProjections} = useContext(StoreContext);
     const {draftedPlayers} = useContext(DraftContext);
@@ -212,7 +214,7 @@ const PlayerList = ({ editable }: any) => {
                             <th className="adp-header">ADP</th>
                             <th className="rank-source-header">ESPN</th>
                             <th className="rank-source-header">FPRO</th>
-                            <th className="vs-adp-header">vsADP</th>
+                            <th className="vs-adp-header">{posFilter && SIMPLE_POSITION_FILTERS.has(posFilter) ? 'vsFPRO' : 'vsADP'}</th>
                             <th className="spacer-header"></th>
                             {columns.map(col => (
                                 <th
@@ -255,6 +257,7 @@ const PlayerList = ({ editable }: any) => {
                                                 rank={rank}
                                                 columns={columns}
                                                 playerRanking={playerRanking}
+                                                posFilter={posFilter}
                                                 editable
                                                 onNameClick={() => setShowCardForPlayerId(playerId)}
                                                 showNote={noteVisible}
@@ -281,6 +284,7 @@ const PlayerList = ({ editable }: any) => {
                                                 rank={rank}
                                                 columns={columns}
                                                 playerRanking={playerRanking}
+                                                posFilter={posFilter}
                                                 onNameClick={() => setShowCardForPlayerId(playerId)}
                                                 showNote={noteVisible}
                                                 isEditing={noteEditing}

--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -35,7 +35,7 @@ function build_player_store(
     stats: Record<number, any>,
     projections: Record<number, any>,
     historical_stats: Record<number, any>,
-    fantasypros_ranks: Record<number, { rank: number; adp: number | null }>
+    fantasypros_ranks: Record<number, { rank: number; adp: number | null; positionalRanks: Record<string, number> }>
 ): Player[] {
     const players: Player[] = player_details.map(player => {
         const current_stats = format_player_stats(stats[player.id], player.eligible_slots);
@@ -61,6 +61,7 @@ function build_player_store(
             birthDate: player.birth_date || null,
             espnRank: player.espn_rank || null,
             fantasyProsRank: fp_data?.rank || null,
+            fantasyProsPositionalRank: fp_data?.positionalRanks ?? null,
         };
     });
 

--- a/server/services/fantasypros.ts
+++ b/server/services/fantasypros.ts
@@ -113,14 +113,51 @@ function parse_ranking_table(html: string): FantasyProsPlayer[] {
 }
 
 /**
+ * Normalize FantasyPros position strings to match app position abbreviations
+ */
+function normalize_position(position: string): string {
+    const pos = position.trim().toUpperCase();
+    if (pos === 'LF' || pos === 'CF' || pos === 'RF') return 'OF';
+    return pos;
+}
+
+/**
+ * Compute positional ranks from the overall rankings list.
+ * Players are already sorted by overall ECR rank, so we assign
+ * within-position ranks (1, 2, 3...) in that order.
+ * Returns a map of player name (lowercase, accent-normalized) -> { position -> positional rank }
+ */
+function compute_positional_ranks(
+    fp_players: FantasyProsPlayer[]
+): Map<string, Record<string, number>> {
+    const position_counters: Record<string, number> = {};
+    const result = new Map<string, Record<string, number>>();
+
+    for (const player of fp_players) {
+        const pos = normalize_position(player.position);
+        if (!pos) continue;
+
+        position_counters[pos] = (position_counters[pos] || 0) + 1;
+        const name_key = replace_accented_characters(player.name).toLowerCase();
+        const existing = result.get(name_key) || {};
+        existing[pos] = position_counters[pos];
+        result.set(name_key, existing);
+    }
+
+    return result;
+}
+
+/**
  * Match FantasyPros players to our player details by name
- * Returns a map of ESPN player ID -> { rank, adp }
+ * Returns a map of ESPN player ID -> { rank, adp, positionalRanks }
  */
 export function match_fantasypros_to_players(
     fp_players: FantasyProsPlayer[],
     player_details: PlayerDetails[]
-): Record<number, { rank: number; adp: number | null }> {
-    const result: Record<number, { rank: number; adp: number | null }> = {};
+): Record<number, { rank: number; adp: number | null; positionalRanks: Record<string, number> }> {
+    const result: Record<number, { rank: number; adp: number | null; positionalRanks: Record<string, number> }> = {};
+
+    const positional_ranks = compute_positional_ranks(fp_players);
 
     // Build a name lookup for our players
     const name_to_player = new Map<string, PlayerDetails>();
@@ -147,6 +184,7 @@ export function match_fantasypros_to_players(
             result[matched.id] = {
                 rank: fp.rank,
                 adp: fp.adp,
+                positionalRanks: positional_ranks.get(normalized_name) || {},
             };
         }
     }

--- a/server/types.ts
+++ b/server/types.ts
@@ -36,6 +36,7 @@ export interface Player {
     birthDate: string | null;
     espnRank: number | null;
     fantasyProsRank: number | null;
+    fantasyProsPositionalRank: Record<string, number> | null;
 }
 
 // Note: Ranking uses camelCase for stored field names to maintain


### PR DESCRIPTION
## Summary
This PR adds support for positional rankings from FantasyPros data, allowing the app to display position-specific rankings and comparisons alongside overall rankings and ADP.

## Key Changes

- **Backend (fantasypros.ts)**:
  - Added `normalize_position()` function to standardize position strings (e.g., LF/CF/RF → OF)
  - Added `compute_positional_ranks()` function to calculate per-position rankings from the overall rankings list
  - Updated `match_fantasypros_to_players()` to include positional ranks in the returned data structure

- **Backend (admin.ts & types.ts)**:
  - Extended the `Player` interface with `fantasyProsPositionalRank` field to store position-specific rankings
  - Updated `build_player_store()` to populate positional rank data from FantasyPros

- **Frontend (PlayerItem.tsx)**:
  - Added `SIMPLE_POSITION_FILTERS` constant to identify single-position filters
  - Updated component to accept `posFilter` prop
  - Modified the "vsADP" column to display positional rank comparisons when a simple position filter is active
  - Comparison logic: shows difference between positional rank and current rank with color coding (gold for >50, green for >10, red for <-10)

- **Frontend (PlayerList.tsx)**:
  - Added `SIMPLE_POSITION_FILTERS` constant
  - Updated column header to dynamically show "vsFPRO" when a position filter is active, otherwise "vsADP"
  - Passed `posFilter` prop to PlayerItem components

## Implementation Details

- Positional ranks are computed in order of overall ECR ranking, so players are ranked 1, 2, 3... within each position based on their overall ranking order
- Player name matching uses accent-normalized lowercase keys for consistency
- The positional comparison only displays when a simple position filter (C, 1B, 2B, SS, 3B, OF, DH, SP, RP) is active; complex filters like "1B/3B" fall back to ADP comparison

https://claude.ai/code/session_011owQtRh8jvuuMUv26sps6g