### PR TITLE
Filter stale player IDs from rankings and add null checks

### DIFF
--- a/client/src/components/PlayerList/PlayerCard.tsx
+++ b/client/src/components/PlayerList/PlayerCard.tsx
@@ -23,6 +23,7 @@ const PlayerCard = ({ playerId, onClose }) => {
     const { expandedStatsView, selectedBattingStats, selectedPitchingStats } = useContext(StatsPrefsContext);
     
     const player      = players[playerId]
+    if (!player) return null
     const projections = player.projections
     const stats       = player.stats
 

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -98,6 +98,7 @@ const PlayerItem = (props) => {
     const isDraftMode = mode === 'draft';
 
     const player = players[playerId]
+    if (!player) return null
     const projections = player.projections
 
     let positions = player.pos.filter(position => !EXCLUDED_POSITIONS.includes(position))

--- a/client/src/data/useUserRanking.tsx
+++ b/client/src/data/useUserRanking.tsx
@@ -4,6 +4,18 @@ import { fetchRanking, createRanking, updateRanking as updateRemoteRanking } fro
 const MAX_STORED_RANKINGS = 10;
 const RANKINGS_STORAGE_KEY = 'storedRankings';
 
+// Remove player IDs from a ranking that no longer exist in the current player data
+function filterStalePlayers(rankingData, currentPlayers) {
+    if (!currentPlayers || !rankingData?.players) return rankingData;
+    const filtered = {};
+    for (const id in rankingData.players) {
+        if (currentPlayers[id]) {
+            filtered[id] = rankingData.players[id];
+        }
+    }
+    return { ...rankingData, players: filtered };
+}
+
 const useUserRanking = (players) => {
     // Get the ranking ID from URL if present
     const getUrlRankingId = () => {
@@ -161,8 +173,8 @@ const useUserRanking = (players) => {
                     const storedRanking = localStorage.getItem(`ranking_${rankingId}`);
                     
                     if (storedRanking) {
-                        // Use the stored version
-                        const parsedRanking = JSON.parse(storedRanking);
+                        // Use the stored version, filtering out stale player IDs
+                        const parsedRanking = filterStalePlayers(JSON.parse(storedRanking), players);
                         setRanking(parsedRanking);
                         setIsShared(!rankingId.startsWith('local'));
                         return; // Exit early after loading the URL ranking
@@ -185,7 +197,7 @@ const useUserRanking = (players) => {
                     const storedRanking = localStorage.getItem(`ranking_${mostRecentId}`);
                     
                     if (storedRanking) {
-                        setRanking(JSON.parse(storedRanking));
+                        setRanking(filterStalePlayers(JSON.parse(storedRanking), players));
                         setIsShared(!mostRecentId.startsWith('local'));
                     } else {
                         // Create new if we can't find the stored data
@@ -244,7 +256,7 @@ const useUserRanking = (players) => {
             
             let targetRanking;
             if (storedRanking) {
-                targetRanking = JSON.parse(storedRanking);
+                targetRanking = filterStalePlayers(JSON.parse(storedRanking), players);
             } else if (rankingId.startsWith('local')) {
                 // If it's a local ranking but we don't have it stored, create a new one
                 return createNewRanking(players);


### PR DESCRIPTION
## Summary
This PR improves the robustness of the ranking system by filtering out player IDs that no longer exist in the current player data, and adds defensive null checks in player-related components.

## Key Changes
- **Added `filterStalePlayers()` function** in `useUserRanking.tsx` to remove player IDs from stored rankings that are no longer present in the current player dataset
- **Applied filtering to all ranking loads** - the function is now called when:
  - Loading a ranking from URL
  - Loading the most recent ranking on app initialization
  - Loading a ranking by ID from storage
- **Added null safety checks** in `PlayerCard.tsx` and `PlayerItem.tsx` to return early if a player doesn't exist, preventing potential crashes when accessing undefined player data

## Implementation Details
The `filterStalePlayers()` function iterates through the players in a stored ranking and only keeps those that exist in the current player data, preserving the ranking structure while removing stale references. This ensures rankings remain valid even when the underlying player dataset changes (e.g., players are removed or data is refreshed).

https://claude.ai/code/session_01326umiXdf3fTHr8Aoe3SPw