### PR TITLE
Add draft note indicator and improve draft mode UI

### DIFF
--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1014,6 +1014,16 @@ button[data-disabled] {
   width: 48px;
 }
 
+.draft-note-icon {
+  color: var(--brown);
+  opacity: 0.6;
+  margin-left: 0.3rem;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  cursor: default;
+}
+
 /* Rank cell */
 .rank-cell {
   font-size: 0.75rem;
@@ -1300,6 +1310,7 @@ button[data-disabled] {
 
 /* Border-radius on the cell before actions (the visual row end) */
 .player-row td:has(+ .actions-cell) { border-radius: 0 6px 6px 0; }
+.draft-mode .player-row td:has(+ .actions-cell) { border-radius: 0; }
 
 /* No highlight border on actions overlay — the left tab is sufficient */
 
@@ -1318,8 +1329,8 @@ button[data-disabled] {
   padding: 0.15rem 0.3rem !important;
   position: static;
   overflow: hidden;
-  background: var(--soft-tan) !important;
   opacity: 1;
+  border-radius: 0 6px 6px 0;
 }
 
 /* Icon buttons */
@@ -1552,15 +1563,15 @@ button {
   &.draft-button {
     background: var(--forest);
     opacity: 1;
-    padding: .5rem 1rem;
-    font-size: .875rem;
+    padding: .25rem .75rem;
+    font-size: .75rem;
   }
-  
+
   &.drafted-button {
     background: var(--navy);
     opacity: 1;
-    padding: .5rem 1rem;
-    font-size: .875rem;
+    padding: .25rem .75rem;
+    font-size: .75rem;
   }
 }
 

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -56,6 +56,12 @@ const CheckIcon = () => (
     </svg>
 )
 
+const CommentIcon = () => (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+    </svg>
+)
+
 const RowActions = ({ playerId, playerRanking, showNote, isEditing, onToggleNote }) => {
     const {ignorePlayer, highlightPlayer} = useContext(StoreContext);
     const hasNote = !!playerRanking?.note;
@@ -160,6 +166,11 @@ const PlayerItem = (props) => {
                         <span className="player-name" onClick={onNameClick}>{player.name}</span>
                         {injuryLabel && (
                             <span className="injury-designation">{injuryLabel}</span>
+                        )}
+                        {isDraftMode && playerRanking?.note && (
+                            <span className="draft-note-icon" title={playerRanking.note}>
+                                <CommentIcon />
+                            </span>
                         )}
                     </div>
                     <div className="player-meta small">

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -230,7 +230,7 @@ const PlayerList = ({ editable }: any) => {
                                     )}
                                 </th>
                             ))}
-                            {editable && <th className="actions-header"></th>}
+                            {(editable || isDraftMode) && <th className="actions-header"></th>}
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
## Summary
Enhanced the draft mode user interface by adding a visual indicator for players with notes and refining the styling of draft-related buttons and layout.

## Key Changes
- **Draft note indicator**: Added a comment icon that appears next to player names in draft mode when they have an associated note, with a tooltip showing the note content
- **New CSS styling**: 
  - Added `.draft-note-icon` class for styling the comment icon (brown color, semi-transparent, inline-flex layout)
  - Modified `.actions-cell` styling to remove background color and add border-radius
  - Added draft mode-specific rule to remove border-radius on player rows when in draft mode
- **Button refinements**: Reduced padding and font size for draft and drafted buttons (from `.5rem 1rem` / `.875rem` to `.25rem .75rem` / `.75rem`)
- **Actions column visibility**: Made the actions column header visible in draft mode (previously only shown when editable)

## Implementation Details
- The comment icon is a new `CommentIcon` SVG component matching the existing icon pattern
- The draft note indicator only displays when `isDraftMode` is true and the player has a note
- CSS changes maintain visual consistency while optimizing space usage in draft mode

https://claude.ai/code/session_017vQcvQJR6rqh81pZL3hABH