### PR TITLE
Update PlayerList column header from vsFPRO to vsPRK

### DIFF
--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -214,7 +214,7 @@ const PlayerList = ({ editable }: any) => {
                             <th className="adp-header">ADP</th>
                             <th className="rank-source-header">ESPN</th>
                             <th className="rank-source-header">FPRO</th>
-                            <th className="vs-adp-header">{posFilter && SIMPLE_POSITION_FILTERS.has(posFilter) ? 'vsFPRO' : 'vsADP'}</th>
+                            <th className="vs-adp-header">{posFilter && SIMPLE_POSITION_FILTERS.has(posFilter) ? 'vsPRK' : 'vsADP'}</th>
                             <th className="spacer-header"></th>
                             {columns.map(col => (
                                 <th


### PR DESCRIPTION
## Summary
Updated the conditional column header text in the PlayerList component to display 'vsPRK' instead of 'vsFPRO' when a simple position filter is applied.

## Changes
- Modified the "vs-adp-header" column header logic in PlayerList.tsx to show 'vsPRK' instead of 'vsFPRO' when `posFilter` is set and matches a simple position filter

## Details
This change updates the ranking comparison column header to use 'vsPRK' (likely "vs PickRank") as the metric name instead of 'vsFPRO' (vs FantasyPros) when filtering by position. The header will still display 'vsADP' when no position filter is applied.

https://claude.ai/code/session_01NQ7YBsU16fMa4rdyumWkvP