### PR TITLE
Sort players by ADP instead of ownership percentage

### DIFF
--- a/server/routes/admin.ts
+++ b/server/routes/admin.ts
@@ -66,7 +66,11 @@ function build_player_store(
         };
     });
 
-    players.sort((a, b) => b.ownership - a.ownership);
+    players.sort((a, b) => {
+        const adpA = a.averageDraftPosition ?? Infinity;
+        const adpB = b.averageDraftPosition ?? Infinity;
+        return adpA - adpB;
+    });
     return players;
 }
 

--- a/server/services/espn.ts
+++ b/server/services/espn.ts
@@ -63,8 +63,8 @@ export async function fetch_player_stats(): Promise<PlayerData> {
                 players: {
                     filterSlotIds: { value: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 19] },
                     filterRanksForScoringPeriodIds: { value: [162] },
-                    sortPercOwned: { sortPriority: 1, sortAsc: false },
-                    sortDraftRanks: { sortPriority: 100, sortAsc: true, value: 'STANDARD' },
+                    sortDraftRanks: { sortPriority: 1, sortAsc: true, value: 'STANDARD' },
+                    sortPercOwned: { sortPriority: 100, sortAsc: false },
                     limit: 700,
                 },
             }),
@@ -84,7 +84,8 @@ export async function fetch_player_stats(): Promise<PlayerData> {
                 players: {
                     filterSlotIds: { value: [13, 14, 15, 17] },
                     filterRanksForScoringPeriodIds: { value: [162] },
-                    sortPercOwned: { sortPriority: 1, sortAsc: false },
+                    sortDraftRanks: { sortPriority: 1, sortAsc: true, value: 'STANDARD' },
+                    sortPercOwned: { sortPriority: 100, sortAsc: false },
                     limit: 600,
                 },
             }),

--- a/server/services/storage.ts
+++ b/server/services/storage.ts
@@ -36,7 +36,11 @@ export async function get_all_players(): Promise<Player[]> {
     for await (const entry of entries) {
         players.push(entry.value as Player);
     }
-    players.sort((a, b) => b.ownership - a.ownership);
+    players.sort((a, b) => {
+        const adpA = a.averageDraftPosition ?? Infinity;
+        const adpB = b.averageDraftPosition ?? Infinity;
+        return adpA - adpB;
+    });
     return players;
 }
 


### PR DESCRIPTION
## Summary
Changed player sorting logic across the application to prioritize Average Draft Position (ADP) over ownership percentage, making draft rankings the primary sort criterion.

## Key Changes
- **ESPN API queries** (`server/services/espn.ts`):
  - Swapped sort priorities for `sortDraftRanks` and `sortPercOwned`
  - `sortDraftRanks` now has priority 1 (primary sort)
  - `sortPercOwned` moved to priority 100 (secondary sort)
  - Applied to both position groups (slots 0-12,19 and slots 13-15,17)

- **Player sorting logic** (`server/routes/admin.ts` and `server/services/storage.ts`):
  - Replaced ownership-based sorting with ADP-based sorting
  - New sort compares `averageDraftPosition` values
  - Handles missing ADP values by treating them as `Infinity` (sorted to end)
  - Applied consistently across both player retrieval functions

## Implementation Details
The ADP sorting uses a null-coalescing approach where players without an ADP value are treated as having infinite ADP, ensuring they appear at the end of the sorted list rather than causing comparison errors.

https://claude.ai/code/session_015tnv9YyDZrMfVFA3kSGaZf