### PR TITLE
Stabilize player rankings in draft mode by including drafted players

### DIFF
--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -97,7 +97,8 @@ const RowActions = memo(function RowActions({ playerId, playerRanking, showNote,
 })
 
 const PlayerItem = memo(function PlayerItem(props: any) {
-    const {playerId, playerRanking, editable, onNameClick, columns, rank, posFilter, showNote, isEditing, onToggleNote} = props
+    const {playerId, playerRanking, editable, onNameClick, columns, rank, vsAdpRank: vsAdpRankProp, posFilter, showNote, isEditing, onToggleNote} = props
+    const vsAdpRank = vsAdpRankProp ?? rank;
     const {players, teams, mode, ranking} = useContext(StoreContext);
     const {isMyTurn, draftPlayer} = useContext(DraftContext);
 
@@ -213,7 +214,7 @@ const PlayerItem = memo(function PlayerItem(props: any) {
                     if (isPositionalMode) {
                         const fproRank = player.fantasyProsPositionalRank?.[posFilter];
                         if (!fproRank) return <span className="stat-neutral">—</span>;
-                        const diff = fproRank - rank;
+                        const diff = fproRank - vsAdpRank;
                         let className = 'vs-adp-neutral';
                         if (diff > 50) className = 'vs-adp-gold';
                         else if (diff > 10) className = 'vs-adp-green';
@@ -222,7 +223,7 @@ const PlayerItem = memo(function PlayerItem(props: any) {
                     }
                     if (!player.averageDraftPosition) return <span className="stat-neutral">—</span>;
                     const adpRound = Math.round(player.averageDraftPosition);
-                    const diff = adpRound - rank;
+                    const diff = adpRound - vsAdpRank;
                     let className = 'vs-adp-neutral';
                     if (diff > 50) className = 'vs-adp-gold';
                     else if (diff > 10) className = 'vs-adp-green';

--- a/client/src/components/PlayerList/PlayerItem.tsx
+++ b/client/src/components/PlayerList/PlayerItem.tsx
@@ -97,8 +97,7 @@ const RowActions = memo(function RowActions({ playerId, playerRanking, showNote,
 })
 
 const PlayerItem = memo(function PlayerItem(props: any) {
-    const {playerId, playerRanking, editable, onNameClick, columns, rank, vsAdpRank: vsAdpRankProp, posFilter, showNote, isEditing, onToggleNote} = props
-    const vsAdpRank = vsAdpRankProp ?? rank;
+    const {playerId, playerRanking, editable, onNameClick, columns, rank, posFilter, showNote, isEditing, onToggleNote} = props
     const {players, teams, mode, ranking} = useContext(StoreContext);
     const {isMyTurn, draftPlayer} = useContext(DraftContext);
 
@@ -214,7 +213,7 @@ const PlayerItem = memo(function PlayerItem(props: any) {
                     if (isPositionalMode) {
                         const fproRank = player.fantasyProsPositionalRank?.[posFilter];
                         if (!fproRank) return <span className="stat-neutral">—</span>;
-                        const diff = fproRank - vsAdpRank;
+                        const diff = fproRank - rank;
                         let className = 'vs-adp-neutral';
                         if (diff > 50) className = 'vs-adp-gold';
                         else if (diff > 10) className = 'vs-adp-green';
@@ -223,7 +222,7 @@ const PlayerItem = memo(function PlayerItem(props: any) {
                     }
                     if (!player.averageDraftPosition) return <span className="stat-neutral">—</span>;
                     const adpRound = Math.round(player.averageDraftPosition);
-                    const diff = adpRound - vsAdpRank;
+                    const diff = adpRound - rank;
                     let className = 'vs-adp-neutral';
                     if (diff > 50) className = 'vs-adp-gold';
                     else if (diff > 10) className = 'vs-adp-green';

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -140,6 +140,27 @@ const PlayerList = ({ editable }: any) => {
         return map;
     }, [rankedBeforeSort]);
 
+    // In draft mode, vsADP rank should reflect a player's position in the full list
+    // (including drafted players) so the comparison stays accurate as picks are made.
+    const vsAdpRankByPlayerId = useMemo(() => {
+        if (!isDraftMode) return rankByPlayerId;
+        // Same filters as rankedBeforeSort but without the drafted-player exclusion
+        let filtered = rankedPlayerIds.filter(id => {
+            const player = players?.[id];
+            if (!player) return false;
+            if (!posFilter) return true;
+            if (posFilter === 'DH') return player.pos.every(p => p === 'DH' || p === 'UTIL');
+            return player.pos.includes(posFilter);
+        });
+        if (searchQuery) {
+            const q = searchQuery.toLowerCase();
+            filtered = filtered.filter(id => players[id]?.name.toLowerCase().includes(q));
+        }
+        const map = new Map<string, number>();
+        filtered.forEach((id, i) => { map.set(id, i + 1); });
+        return map;
+    }, [isDraftMode, rankByPlayerId, rankedPlayerIds, players, posFilter, searchQuery]);
+
     // Apply sort on top for visual ordering only
     const displayedPlayerIds = useMemo(() => {
         if (!sortColumn) return rankedBeforeSort;
@@ -259,6 +280,7 @@ const PlayerList = ({ editable }: any) => {
                                 // Rank = 1-based position in the pre-sort filtered list
                                 // (reflects live drag order and position-filtered context)
                                 const rank = rankByPlayerId.get(playerId) || 0;
+                                const vsAdpRank = vsAdpRankByPlayerId.get(playerId) || rank;
                                 const playerRanking = ranking.players[playerId];
                                 const isEven = visualIndex % 2 === 1;
                                 const rowClass = `player-row${isEven ? ' even-row' : ''}${playerRanking?.highlight ? ' highlighted' : playerRanking?.ignore ? ' ignored' : ''}`;
@@ -272,6 +294,7 @@ const PlayerList = ({ editable }: any) => {
                                             <PlayerItem
                                                 playerId={playerId}
                                                 rank={rank}
+                                                vsAdpRank={vsAdpRank}
                                                 columns={columns}
                                                 playerRanking={playerRanking}
                                                 posFilter={posFilter}
@@ -299,6 +322,7 @@ const PlayerList = ({ editable }: any) => {
                                             <PlayerItem
                                                 playerId={playerId}
                                                 rank={rank}
+                                                vsAdpRank={vsAdpRank}
                                                 columns={columns}
                                                 playerRanking={playerRanking}
                                                 posFilter={posFilter}

--- a/client/src/components/PlayerList/PlayerList.tsx
+++ b/client/src/components/PlayerList/PlayerList.tsx
@@ -277,10 +277,10 @@ const PlayerList = ({ editable }: any) => {
                             strategy={verticalListSortingStrategy}
                         >
                             {displayedPlayerIds.map((playerId, visualIndex) => {
-                                // Rank = 1-based position in the pre-sort filtered list
-                                // (reflects live drag order and position-filtered context)
-                                const rank = rankByPlayerId.get(playerId) || 0;
-                                const vsAdpRank = vsAdpRankByPlayerId.get(playerId) || rank;
+                                // In draft mode, rank reflects position in the full list (including
+                                // drafted players) so numbers stay stable as players are picked.
+                                // Outside draft mode, rank is position in the filtered list.
+                                const rank = vsAdpRankByPlayerId.get(playerId) || 0;
                                 const playerRanking = ranking.players[playerId];
                                 const isEven = visualIndex % 2 === 1;
                                 const rowClass = `player-row${isEven ? ' even-row' : ''}${playerRanking?.highlight ? ' highlighted' : playerRanking?.ignore ? ' ignored' : ''}`;
@@ -294,7 +294,6 @@ const PlayerList = ({ editable }: any) => {
                                             <PlayerItem
                                                 playerId={playerId}
                                                 rank={rank}
-                                                vsAdpRank={vsAdpRank}
                                                 columns={columns}
                                                 playerRanking={playerRanking}
                                                 posFilter={posFilter}
@@ -322,7 +321,6 @@ const PlayerList = ({ editable }: any) => {
                                             <PlayerItem
                                                 playerId={playerId}
                                                 rank={rank}
-                                                vsAdpRank={vsAdpRank}
                                                 columns={columns}
                                                 playerRanking={playerRanking}
                                                 posFilter={posFilter}


### PR DESCRIPTION
## Summary
Modified the PlayerList component to use a separate ranking calculation in draft mode that includes drafted players. This ensures player rank numbers remain stable as picks are made, rather than shifting as drafted players are filtered out.

## Key Changes
- Added `vsAdpRankByPlayerId` memo that calculates rankings including all players (drafted and undrafted) when in draft mode
- Updated the rank calculation to use `vsAdpRankByPlayerId` instead of `rankByPlayerId` for display
- Maintained the same filtering logic (position filter, search query) but removed the drafted-player exclusion filter for draft mode rankings
- Updated comments to clarify the different ranking behaviors between draft and non-draft modes

## Implementation Details
- The new `vsAdpRankByPlayerId` memo only activates when `isDraftMode` is true; otherwise it returns the standard `rankByPlayerId`
- Filtering logic mirrors `rankedBeforeSort` but preserves drafted players in the ranking calculation
- This allows the displayed rank to reflect a player's position in the complete player pool, keeping ADP comparisons accurate throughout the draft process

https://claude.ai/code/session_013FUDigXMWC2W92zw127CMt